### PR TITLE
Adapt for Static Export and Dynamic API Location

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,0 @@
-DIRACX_CLIENT_ID=myDIRACClientID
-REDIRECT_URI=http://localhost:3000/dashboard/#authentication-callback
-DEFAULT_SCOPE="vo:diracAdmin"
-NEXT_PUBLIC_DIRACX_URL=http://localhost:8000

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,0 @@
-DIRACX_CLIENT_ID=interactive.public.short
-REDIRECT_URI=http://localhost:3000/dashboard/#authentication-callback
-DEFAULT_SCOPE="openid profile email api offline_access"
-NEXT_PUBLIC_DIRACX_URL=https://demo.duendesoftware.com

--- a/.github/workflows/containerised.yml
+++ b/.github/workflows/containerised.yml
@@ -27,5 +27,5 @@ jobs:
               with:
                 context: .
                 push: ${{ github.event_name == 'push' && github.repository == 'DIRACGrid/diracx-web' && github.ref_name == 'main' }}
-                tags: ghcr.io/diracgrid/diracx-web/client:latest
+                tags: ghcr.io/diracgrid/diracx-web/static:latest
                 platforms: linux/amd64,linux/arm64

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+};
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "diracx-webapp",
+  "name": "diracx-web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "diracx-webapp",
+      "name": "diracx-web",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/src/app/dashboard/jobmonitor/[id]/page.tsx
+++ b/src/app/dashboard/jobmonitor/[id]/page.tsx
@@ -1,3 +1,0 @@
-export default function Page({ params }: { params: { id: string } }) {
-  return <h1>Hello, Job Monitoring {params.id} Page!</h1>;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,17 @@
 import "./globals.css";
 import { Inter } from "next/font/google";
 import { OIDCProvider } from "@/components/auth/OIDCUtils";
-import { OidcConfiguration } from "@axa-fr/react-oidc";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
-  title: "diracX",
+  title: "DiracX",
   description: "Distributed Infrastructure with Remote Agent Controller",
 };
 
-const configuration: OidcConfiguration = {
-  client_id: process.env.DIRACX_CLIENT_ID || "",
-  redirect_uri: process.env.REDIRECT_URI || "",
-  scope: process.env.DEFAULT_SCOPE || "",
-  authority: process.env.NEXT_PUBLIC_DIRACX_URL || "",
-};
+// Force an error if any components use dynamic functions or uncached data
+// as these won't work in the static export.
+export const dynamic = "error";
 
 export default function RootLayout({
   children,
@@ -25,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <OIDCProvider configuration={configuration}>{children}</OIDCProvider>
+        <OIDCProvider>{children}</OIDCProvider>
       </body>
     </html>
   );

--- a/src/components/auth/OIDCUtils.tsx
+++ b/src/components/auth/OIDCUtils.tsx
@@ -4,10 +4,10 @@ import {
   OidcProvider,
   OidcSecure,
 } from "@axa-fr/react-oidc";
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useDiracxUrl } from "@/hooks/utils";
 
 interface OIDCProviderProps {
-  configuration: OidcConfiguration;
   children: React.ReactNode;
 }
 
@@ -30,11 +30,32 @@ export function OIDCProvider(props: OIDCProviderProps) {
       },
     };
   };
+  const diracxUrl = useDiracxUrl();
+  const [configuration, setConfiguration] = useState<OidcConfiguration | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (diracxUrl !== null) {
+      setConfiguration((prevConfig) => ({
+        authority: diracxUrl,
+        // TODO: Figure out how to get this. Hardcode? Get from a /.well-known/diracx-configuration endpoint?
+        client_id: "myDIRACClientID",
+        // TODO: Get this from the /.well-known/openid-configuration endpoint
+        scope: "vo:diracAdmin",
+        redirect_uri: `${diracxUrl}/#authentication-callback`,
+      }));
+    }
+  }, [diracxUrl]);
+
+  if (configuration === null) {
+    return <></>;
+  }
 
   return (
     <>
       <OidcProvider
-        configuration={props.configuration}
+        configuration={configuration}
         withCustomHistory={withCustomHistory}
       >
         <main>{props.children}</main>

--- a/src/hooks/jobs.tsx
+++ b/src/hooks/jobs.tsx
@@ -1,5 +1,6 @@
 import { useOidcAccessToken } from "@axa-fr/react-oidc";
 import useSWR from "swr";
+import { useDiracxUrl } from "./utils";
 
 const fetcher = (args: any[]) => {
   const [url, accessToken] = args;
@@ -14,9 +15,14 @@ const fetcher = (args: any[]) => {
 };
 
 export function useJobs() {
+  const diracxUrl = useDiracxUrl();
   const { accessToken } = useOidcAccessToken();
-  const url = `${process.env.NEXT_PUBLIC_DIRACX_URL}/api/jobs/search?page=0&per_page=100`;
+  const url = `${diracxUrl}/api/jobs/search?page=0&per_page=100`;
   const { data, error } = useSWR([url, accessToken], fetcher);
+
+  if (diracxUrl === null) {
+    return { data: null, error: "diracxUrl is null", isLoading: false };
+  }
 
   return {
     data,

--- a/src/hooks/utils.tsx
+++ b/src/hooks/utils.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useDiracxUrl() {
+  const [diracxUrl, setDiracxUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Ensure this runs on client side
+    if (typeof window !== "undefined") {
+      setDiracxUrl(
+        (prevConfig) => `${window.location.protocol}//${window.location.host}`,
+      );
+    }
+  }, []);
+
+  return diracxUrl;
+}


### PR DESCRIPTION
When adding TLS to the demo I ran into issues with the OIDC stuff being done server side (and therefore not trusting the custom CA used by the demo).

The main changes are:

* Introduced a new hook, `useDiracxUrl`, to dynamically determine the API’s URL based on the client’s `window.location`.
* Move to using nginx to serve the application in the docker image.
* Move the OIDC stuff client side.

I have a corrosponding PR to update the charts repo as well.