### PR TITLE
feat: GitHub discussion templates 

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/design-ideas.yaml
+++ b/.github/DISCUSSION_TEMPLATE/design-ideas.yaml
@@ -1,0 +1,45 @@
+title: "<Title of the Design Idea>"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for proposing a design idea!
+        Please provide the details below to help us understand the context and rationale behind this idea.
+        Make sure to link this design idea to a user story to showcase the need for this design.
+
+  - type: input
+    id: user-story-link
+    attributes:
+      label: Link to User Story
+      placeholder: "URL to the related user story"
+    validations:
+      required: false
+
+  - type: textarea
+    id: current-approach-problem
+    attributes:
+      label: Problem with Current Approach
+      description: "Describe the problem with the current approach, if any. Explain what's lacking or why it's not satisfactory."
+      placeholder: "Explain the problem..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: design-solution
+    attributes:
+      label: Proposed Design Solution
+      description: "Explain how your design idea solves the problem. Describe the design changes in detail."
+      placeholder: "Describe your design solution..."
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        If possible, please attach an image representing a mockup or sketch of your design idea. Visual representations can help communicate your idea more clearly.
+
+  - type: markdown
+    attributes:
+      value: |
+        Once again, thank you for your contribution. Our team will review your design idea and provide feedback.
+

--- a/.github/DISCUSSION_TEMPLATE/surveys.yaml
+++ b/.github/DISCUSSION_TEMPLATE/surveys.yaml
@@ -1,0 +1,153 @@
+title: "[<Community Name>] User Feedback Survey"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        We value your feedback and would love to hear about your experience with our current web application.
+        Your insights will be instrumental in shaping the new diracx-web client we are building.
+        Please take a moment to answer the questions below.
+
+  - type: markdown
+    attributes:
+      value: "## General"
+
+  - type: textarea
+    id: overall-experience
+    attributes:
+      label: "Describe your overall experience with the current DIRAC web application."
+      description: >
+        Focus on aspects like ease of use, reliability, and speed
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: "What tasks do you primarily use our web application for?"
+      description: >
+        Example: I monitor my jobs.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Features
+        ### For all users
+
+  - type: textarea
+    id: features-used
+    attributes:
+      label: "What features do you find most useful and why?"
+      description: >
+        Example: The possibility of monitoring my jobs in real-time.
+    validations:
+      required: true
+
+  - type: textarea
+    id: frustrating-features
+    attributes:
+      label: "Are there any features or functionalities you find frustrating or difficult to use?"
+      description: >
+        Example: I am lost with all these pages.
+    validations:
+      required: true
+
+  - type: textarea
+    id: bugs
+    attributes:
+      label: "Have you encountered any bugs or issues while using the application? If so, describe them."
+      description: >
+        Example: Sometimes I see some messages I do not understand popping up in the interface.
+    validations:
+      required: true
+
+  - type: textarea
+    id: santa-claus-might-be-on-his-way
+    attributes:
+      label: "Are there any features or functionalities you wish were included in the current web application?"
+      description: >
+        Example: Yes, I would like to group my job by CE type!
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "## For Admins only"
+
+  - type: textarea
+    id: admin-features-used
+    attributes:
+      label: "As an admin, what features do you find most useful and why?"
+    validations:
+      required: false
+
+  - type: textarea
+    id: admin-frustrating-features
+    attributes:
+      label: "Are there any admin-specific features or functionalities you find frustrating or difficult to use?"
+    validations:
+      required: false
+
+  - type: textarea
+    id: admin-bugs
+    attributes:
+      label: "Have you encountered any bugs or issues while using the application? If so, describe them."
+    validations:
+      required: false
+
+  - type: textarea
+    id: admin-wishlist
+    attributes:
+      label: "Are there any admin-specific features or functionalities you wish were included in the current web application?"
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "## Design and responsiveness"
+
+  - type: textarea
+    id: design-feeling
+    attributes:
+      label: "How do you feel about the current user interface and design? What changes, if any, would you suggest?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: mobile-experience
+    attributes:
+      label: "Have you ever used the DIRAC web application on mobile devices? Would a mobile-friendly version be beneficial for you?"
+      description: "The adoption of OIDC tokens will open up such possibilities"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "## Extensions"
+
+  - type: textarea
+    id: extension
+    attributes:
+      label: "Are you using a DIRAC web application extension? What do you have in it?"
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "## Any other suggestion"
+
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: "Is there anything else you would like to share or suggest as we work on the diracx-web application?"
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to provide your feedback.
+        Your insights are valuable to us as we work on improving the application.
+        We will keep you updated on our progress and look forward to sharing the new version with you.
+

--- a/.github/DISCUSSION_TEMPLATE/user-personas-and-stories.yaml
+++ b/.github/DISCUSSION_TEMPLATE/user-personas-and-stories.yaml
@@ -1,0 +1,54 @@
+title: "[<Community Name>] <Feature Request>"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Develop a user persona and a story to capture the goals and tasks your users want to accomplish with diracx-web.
+        We are interested in understanding your needs and goals. Please focus on what you want to achieve rather than how you think it should be achieved.
+        All ideas are welcome, and there are no wrong answers. We appreciate your honest feedback as it helps us improve the system to better meet your needs.
+
+  - type: textarea
+    id: user-persona
+    attributes:
+      label: User Persona
+      description: |
+        Who is the user? Here is an example:
+        - Name: John Doe
+        - Age: 32
+        - Occupation: Dirac Developer
+        - Goals: 
+          1. Ease eye strain during long working hours by utilizing a dark mode feature.
+          2. Improve focus and productivity by reducing glare and distraction from a bright screen.
+          3. Maintain a sleek and modern user interface.
+        - Pain points:
+          1. Current bright/light theme of the web app causes eye fatigue, especially when working late into the night.
+          2. The lack of a dark mode feature feels outdated and not in alignment with contemporary design standards.
+          3. Concerned that continued use of the app in its current state may adversely affect my vision over time.
+      value: |
+        - Name:
+        - Age:
+        - Occupation:
+        - Goals:
+        - Pain points:
+    validations:
+      required: true
+
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User Story
+      description: |
+        What does the user want to achieve in this scenario? Here is an example:
+        As a developer, John wants a dark mode feature in the web app so that he can work comfortably during late hours and reduce eye strain, while also enjoying a modern and sleek user interface.
+      placeholder: |
+        As a [type of user], [User] wants [an action] so that [a benefit/a goal].
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-comments
+    attributes:
+      label: Additional Comments or Suggestions
+      description: "Share any other feedback, ideas, or suggestions that can help us understand your needs better."
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -1,22 +1,46 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+![Basic tests](https://github.com/DIRACGrid/diracx-web/actions/workflows/basic.yml/badge.svg?branch=main)
+![Basic tests](https://github.com/DIRACGrid/diracx-web/actions/workflows/test.yml/badge.svg?branch=main)
+![Basic tests](https://github.com/DIRACGrid/diracx-web/actions/workflows/containerised.yml/badge.svg?branch=main)
 
-## Getting Started
+# DiracX-Web Prototype
 
-First, run the development server:
+## Getting started
+
+This will allow you to run a demo setup.
+
+The code changes will be reflected in the demo.
+
+Requirement: docker, internet
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
+# Clone the diracx repository
+git clone git@github.com:DIRACGrid/diracx.git
+
+# Clone the diracx-web repository
+git clone git@github.com:DIRACGrid/diracx-web.git
+
+# Clone the diracx-chart repository
+git clone git@github.com:DIRACGrid/diracx-charts.git
+
+# Run the demo
+diracx-charts/run_demo.sh diracx/ diracx-web/
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:8000](http://localhost:8000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Contributing
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+- Want to report a bug?
+  Open an [Issue](https://github.com/DIRACGrid/diracx-web/issues).
+- Need technical support to configure `diracx-web`?
+  Start a [Support discussion](https://github.com/DIRACGrid/diracx-web/discussions/categories/support).
+
+- Want to make a general feedback about the [DIRAC web application](https://github.com/DIRACGrid/WebAppDIRAC)?
+  Answer to the [Survey](https://github.com/DIRACGrid/diracx-web/discussions/categories/surveys) by creating a new discussion.
+- Want to request a feature?
+  Create a [User Story](https://github.com/DIRACGrid/diracx-web/discussions/categories/user-personas-and-stories) to describe your need.
+- Want to discuss about UX/UI design?
+  Share your [Design idea](https://github.com/DIRACGrid/diracx-web/discussions/categories/design-ideas).
 
 ## Learn More
 
@@ -24,11 +48,3 @@ To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.


### PR DESCRIPTION
- Discussion templates aiming at guiding users so that they clearly describe their needs. :crossed_fingers: 
- Update of the `README` 

Following the proposed current discussion sections and categories, I think:
- https://github.com/DIRACGrid/diracx-web/issues/1 could fit in `Design ideas`
- https://github.com/DIRACGrid/diracx-web/issues/2 could be converted as a `User story`
- Issues would be mostly used to describe bugs and technicalities.

Any opinion about that?