### PR TITLE
fix: nginx does not handle pages with no subdirectory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Minimize the size and complexity of the final Docker image by separating the
 # build stage and the runtime stage into two different steps
+
+# Stage 1: Build the Next.js application
 FROM node:16-alpine AS build
 WORKDIR /app
 # Install the project dependencies
@@ -10,7 +12,8 @@ COPY . .
 # Build the static export with telemetry disabled (https://nextjs.org/telemetry)
 RUN NEXT_TELEMETRY_DISABLED=1 npm run build
 
-# Copy the website from the previous container to a Nginx container
+# Stage 2: Copy the website from the previous container to a Nginx container
 FROM nginxinc/nginx-unprivileged:alpine
 EXPOSE 8080
 COPY --from=build /app/out /usr/share/nginx/html
+COPY ./config/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri.html $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+


### PR DESCRIPTION
Should fix the `404: Not Found` error when we try to access `/auth`. 
By default, the `nginx` configuration does not handle `$uri.html`.  

Therefore, I provide a custom `nginx` configuration file to add the following line:

```
# the important thing is "$uri/"
try_files $uri $uri.html $uri/ /index.html;
```

This was manually tested successfully in the certification environment (I tweaked the configuration directly from the container).