### PR TITLE
fix: update node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # build stage and the runtime stage into two different steps
 
 # Stage 1: Build the Next.js application
-FROM node:16-alpine AS build
+FROM node:alpine AS build
 WORKDIR /app
 # Install the project dependencies
 COPY package*.json ./


### PR DESCRIPTION
`node 16` is not maintained anymore according to https://endoflife.date/nodejs

Would it make sense to use the latest `node` version here?
I guess it does as it is a highly used image. If any issue occurred, it would likely be solved very quickly and would allow us to constantly remain up-to-date.