### PR TITLE
ci(release-please): fix extensions version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,5 @@
   ".": "0.1.0-a1",
   "packages/diracx-web": "0.1.0-a1",
   "packages/diracx-web-components": "0.1.0-a1",
-  "packages/diracx-web-extension-example": "0.1.0-a1"
+  "packages/extensions": "0.1.0-a1"
 }


### PR DESCRIPTION
Should fix Release Please setting the version 1.0.0 to the extension example package and set it to 0.1.0a2 like other packages instead.