### PR TITLE
fix(release-please): diracx-web-components is not correctly updated

### DIFF
--- a/packages/extensions/package-lock.json
+++ b/packages/extensions/package-lock.json
@@ -411,8 +411,6 @@
     },
     "node_modules/@dirac-grid/diracx-web-components": {
       "version": "0.1.0-a2",
-      "resolved": "https://registry.npmjs.org/@dirac-grid/diracx-web-components/-/diracx-web-components-0.1.0-a2.tgz",
-      "integrity": "sha512-fdENHWoIgCo9qlANuboZZS014sWAj5qPI2laCwH3BOqVYUyxUmwrq0LtA96YICUF6+UhtQ70GTyru4ik+QORKg==",
       "license": "GPL-3.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.1.3",


### PR DESCRIPTION
Release Please can't update the `package-lock.json` resolved and integrity fields for `diracx-web-components` in the extension.
Simply deleting the optional resolved and integrity fields fixes the problem.