### PR TITLE
feat: enable remote backend connection

### DIFF
--- a/docs/developer/setup_environment.md
+++ b/docs/developer/setup_environment.md
@@ -99,29 +99,45 @@ flowchart TD
 
 ## Running DiracX-Web in development mode
 
-_Requirements: docker, internet, node_
+_Requirements: node, npm_
 
-This will allow you to run a demo setup:
-
-```bash
-# Clone the diracx-chart repository
-git clone git@github.com:DIRACGrid/diracx-charts.git
-
-# Run the demo
-diracx-charts/run_demo.sh
-```
-
-You can also start the demo setup in development mode - code changes will be reflected in the demo in real time:
+You can start `DiracX-Web` as an `npm` application connecting to a remote backend server - code changes will be reflected in the demo in real time.
 
 ```bash
 # Clone the diracx-web repository
 git clone git@github.com:DIRACGrid/diracx-web.git
 
+cd diracx-web
+
+# Install it
+npm ci
+
+# Set the DiracX backend URL you are targeting
+export NEXT_PUBLIC_DIRACX_URL=<backend url>
+
+# Run it
+npm run dev
+```
+
+## Running DiracX-Web in development mode along DiracX
+
+_Requirements: docker, internet, node_
+
+If you need to modify `DiracX` in parallel, or if you do not have access to the remote backend logs,
+then you can also start the full demo setup in development mode:
+
+```bash
+# Clone the diracx-web repository
+git clone git@github.com:DIRACGrid/diracx-web.git
+
+# [Optional] Clone the diracx repository
+git clone git@github.com:DIRACGrid/diracx.git
+
 # Clone the diracx-chart repository
 git clone git@github.com:DIRACGrid/diracx-charts.git
 
 # Run the demo
-diracx-charts/run_demo.sh ./diracx-web
+diracx-charts/run_demo.sh ./diracx-web [./diracx]
 ```
 
 :bulb: Any change made in `diracx-web-components` are automatically reflected into the development environment. We rely on the [NextJS transpile option](https://nextjs.org/docs/app/api-reference/config/next-config-js/transpilePackages). Further details are available in the [`diracx-web` NextJS configuration](../../packages/diracx-web/next.config.js)

--- a/packages/diracx-web-components/src/components/Login/LoginForm.tsx
+++ b/packages/diracx-web-components/src/components/Login/LoginForm.tsx
@@ -17,6 +17,7 @@ import { useOIDCContext } from "../../hooks/oidcConfiguration";
 
 import { useSearchParamsUtils } from "../../hooks/searchParamsUtils";
 import { NavigationContext } from "../../contexts/NavigationProvider";
+import { useDiracxUrl } from "../../hooks";
 
 interface LoginFormProps {
   /** The URL of the logo, optional */
@@ -32,7 +33,8 @@ export function LoginForm({
   logoURL = "/DIRAC-logo-minimal.png",
 }: LoginFormProps) {
   const { setPath } = useContext(NavigationContext);
-  const { metadata, error, isLoading } = useMetadata();
+  const diracxUrl = useDiracxUrl();
+  const { metadata, error, isLoading } = useMetadata(diracxUrl);
   const [selectedVO, setSelectedVO] = useState<string | null>(null);
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const { configuration, setConfiguration } = useOIDCContext();
@@ -52,6 +54,7 @@ export function LoginForm({
     // Redirect to dashboard if already authenticated
     if (isAuthenticated) {
       const redirect = getParam("redirect");
+      console.log("Redirecting to:", redirect);
       if (redirect) {
         setPath(redirect);
       } else {
@@ -62,7 +65,7 @@ export function LoginForm({
 
   // Get default group
   const getDefaultGroup = (
-    metadata: Metadata | undefined,
+    metadata: Metadata | undefined | null,
     vo: string,
   ): string => {
     if (!metadata) {

--- a/packages/diracx-web-components/src/components/OIDC/OIDCProvider.tsx
+++ b/packages/diracx-web-components/src/components/OIDC/OIDCProvider.tsx
@@ -28,12 +28,14 @@ export function OIDCProvider({ children }: OIDCProviderProps) {
         scope = scope.replace(/^"|"$/g, "");
       }
 
+      const originUri = `${window.location.protocol}//${window.location.host}`;
+
       // Set the OIDC configuration
       setConfiguration({
         authority: diracxUrl,
         client_id: "myDIRACClientID",
         scope: scope,
-        redirect_uri: `${diracxUrl}/#authentication-callback`,
+        redirect_uri: `${originUri}/#authentication-callback`,
       });
     }
   }, [diracxUrl, configuration, setConfiguration]);

--- a/packages/diracx-web-components/src/hooks/metadata.tsx
+++ b/packages/diracx-web-components/src/hooks/metadata.tsx
@@ -28,14 +28,14 @@ export interface Metadata {
  * Fetches the metadata from the /.well-known/dirac-metadata endpoint
  * @returns the metadata
  */
-export function useMetadata() {
-  const url = `/.well-known/dirac-metadata`;
+export function useMetadata(diracxUrl: string | null) {
+  const url = diracxUrl ? `${diracxUrl}/.well-known/dirac-metadata` : null;
 
   const {
     data,
     error,
   }: SWRResponse<{ headers: Headers; data: Metadata }, Error> = useSWRImmutable(
-    [url],
+    url ? [url] : null,
     (args) => fetcher<Metadata>(args),
   );
 
@@ -44,6 +44,6 @@ export function useMetadata() {
   return {
     metadata,
     error,
-    isLoading: !data && !error,
+    isLoading: !data && !error && !!diracxUrl,
   };
 }


### PR DESCRIPTION
Needs: https://github.com/DIRACGrid/diracx/pull/436

It allows developers to run `diracx-web` without having to go through `diracx-charts/run_demo.sh`, by connecting to a remote instance (e.g. diracx certification instance).

Also included:
- better error messages when a request fails
- jobs should not be refreshed on each focus on the web page