### PR TITLE
feat: better cache the intermediate layers in the docker build stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.next

--- a/.github/workflows/gubbins-test.yml
+++ b/.github/workflows/gubbins-test.yml
@@ -194,6 +194,8 @@ jobs:
           name: gubbins-web
           path: /tmp/gubbins-web
           retention-days: 1
+          include-hidden-files: true
+
   # ----------------------------------------------------------------------------#
   # In the following jobs, you should:                                          #
   # - Replace /tmp/gubbins-web with the path to your extension source code      #

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,15 @@
 # Stage 1: Build the Next.js application
 FROM node:alpine AS build
 WORKDIR /app
-# Copy the application to the working directory
+
+# Copy the package.json and package-lock.json files to the working directory
 COPY package*.json ./
-COPY packages/diracx-web ./packages/diracx-web
-COPY packages/diracx-web-components ./packages/diracx-web-components
+COPY packages/diracx-web/package*.json ./packages/diracx-web/
+COPY packages/diracx-web-components/package*.json ./packages/diracx-web-components/
 # Install the project dependencies
-RUN npm ci
+RUN npm ci && npm cache clean --force
+# Copy the application to the working directory
+COPY . .
 # Build the static export with telemetry disabled (https://nextjs.org/telemetry)
 RUN NEXT_TELEMETRY_DISABLED=1 npm run build
 

--- a/packages/extensions/.dockerignore
+++ b/packages/extensions/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.next

--- a/packages/extensions/Dockerfile
+++ b/packages/extensions/Dockerfile
@@ -4,10 +4,19 @@
 # Stage 1: Build the Next.js application
 FROM node:alpine AS build
 WORKDIR /app
+
+# Copy the package.json and package-lock.json files to the working directory
+COPY package*.json ./
+# =============================================================================
+# This line is not necessary in your extension
+# -----------------------------------------------------------------------------
+COPY diracx-web-components.tgz ./
+# =============================================================================
+
+# Install the project dependencies
+RUN npm ci && npm cache clean --force
 # Copy the application to the working directory
 COPY . .
-# Install the project dependencies
-RUN npm ci
 # Build the static export with telemetry disabled (https://nextjs.org/telemetry)
 RUN NEXT_TELEMETRY_DISABLED=1 npm run build
 


### PR DESCRIPTION
... by copying the `package*.json` files before running `npm ci`, and copy the rest of the files at this point.

That was correctly handled in the past, and then at some point I might have overridden the `Dockerfile` incorrectly.
