### PR TITLE
feat: add share and import features

### DIFF
--- a/docs/developer/contribute.md
+++ b/docs/developer/contribute.md
@@ -16,7 +16,18 @@
 - **Code Documentation:** Ensure that any code you write is well-documented. This includes:
   - Inline comments where necessary to explain complex logic.
   - Updating or creating Storybook documentation if you are contributing to the `diracx-web-components` library.
-- **Writing/Updating Tests:** When you change or add new code, make sure to write or update tests accordingly. This helps maintain the reliability and stability of the codebase.
+  - You can use tools like [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/) to maintain code quality.
+
+- **Testing**:
+
+  - **Component Testing**: Write tests for your components to ensure they work as expected. Use [Jest](https://jestjs.io/) for unit testing and snapshot testing of your React components.
+  - **Application Testing**: Use [Cypress](https://www.cypress.io/) for end-to-end testing to simulate real user interactions and ensure your application behaves correctly.
+  - **Test Coverage**: Maintain good test coverage to ensure that your critical features are well-protected during updates. Tools like Jest provide [coverage reports](https://jestjs.io/docs/code-coverage) that help you identify untested parts of your code.
+
+
+- **Accessibility**: Make your application accessible to all users. Use semantic HTML, ARIA attributes, and test your application with different screen sizes and assistive technologies.
+
+By following these practices, you'll ensure that your codebase remains robust, secure, and maintainable.
 
 **Good to know:** If you create an export function or component in `diracx-web-components`, you must add it to the `index.ts` file and run `npm run build` inside `packages/diracx-web-components` to ensure the pre-commit hook passes.
 

--- a/docs/developer/create_application.md
+++ b/docs/developer/create_application.md
@@ -1,0 +1,17 @@
+# Create an application
+
+## In DiracX-Web
+
+The applicatins created here will be available for DiracX-Web and for all the extensions.
+
+### Declare the application
+
+In the file `packages/diracx-web-components/src/components/ApplicationList.ts` you can extend the `applicationList` with your new app. You must provide a name (explicit), the component representing the new app and an icon that will appear in the `Add application` menu. You can also give two functions, `setState` and `getState`, to configure the export and import of your app.
+
+### Code the application
+
+The code of your app should be in `packages/diracx-web-components/src/components/<new-app>`. The new app can and should use what already exist in `@dirac-grid/diracx-web-components`. 
+
+In order to be compatible with the share and import buttons, the application must write its state to the session storage at `<appId>_State`. This slot is read from and written to by the corresponding functions.
+
+💡You can look at `JobMonitor` as an example.

--- a/docs/user/list_and_share_applications.md
+++ b/docs/user/list_and_share_applications.md
@@ -90,3 +90,10 @@ When managing multiple instances of the same application, grouping can help you 
    - :bulb: A context menu will appear.
 2. Select **Delete**.
    - :bulb: The group and all its application instances will disappear from the sidebar.
+
+
+### Share and import the settings of an application
+
+1. **Share**: You can share the status of an app by clicking on the share button in the top-right corner of the screen. After clicking, you can select which group and app you want to share and then copy a text corresponding to the states of the selected applications.
+
+2. **Import**: Next to the share button you can find the import button. You can paste into the window opened by the button the text corresponding to one or multiple shared apps. This will create a new group named *Imported App* with the imported applications and their settings. 

--- a/packages/diracx-web-components/src/components/ApplicationList.ts
+++ b/packages/diracx-web-components/src/components/ApplicationList.ts
@@ -2,7 +2,7 @@
 
 import { Dashboard, FolderCopy, Monitor } from "@mui/icons-material";
 import ApplicationMetadata from "../types/ApplicationMetadata";
-import JobMonitor, { exportState, setState } from "./JobMonitor/JobMonitor";
+import JobMonitor from "./JobMonitor/JobMonitor";
 import BaseApp from "./BaseApp/BaseApp";
 
 export const applicationList: ApplicationMetadata[] = [
@@ -11,8 +11,6 @@ export const applicationList: ApplicationMetadata[] = [
     name: "Job Monitor",
     component: JobMonitor,
     icon: Monitor,
-    getState: exportState,
-    setState: setState,
   },
   {
     name: "File Catalog",

--- a/packages/diracx-web-components/src/components/ApplicationList.ts
+++ b/packages/diracx-web-components/src/components/ApplicationList.ts
@@ -2,7 +2,7 @@
 
 import { Dashboard, FolderCopy, Monitor } from "@mui/icons-material";
 import ApplicationMetadata from "../types/ApplicationMetadata";
-import JobMonitor from "./JobMonitor/JobMonitor";
+import JobMonitor, { exportState, setState } from "./JobMonitor/JobMonitor";
 import BaseApp from "./BaseApp/BaseApp";
 
 export const applicationList: ApplicationMetadata[] = [
@@ -11,6 +11,8 @@ export const applicationList: ApplicationMetadata[] = [
     name: "Job Monitor",
     component: JobMonitor,
     icon: Monitor,
+    getState: exportState,
+    setState: setState,
   },
   {
     name: "File Catalog",

--- a/packages/diracx-web-components/src/components/DashboardLayout/Dashboard.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/Dashboard.tsx
@@ -15,6 +15,8 @@ import {
 import { ProfileButton } from "./ProfileButton";
 import { ThemeToggleButton } from "./ThemeToggleButton";
 import DashboardDrawer from "./DashboardDrawer";
+import { ShareButton } from "./ShareButton";
+import { ImportButton } from "./ImportButton";
 
 interface DashboardProps {
   /** The content to be displayed in the main area */
@@ -121,6 +123,8 @@ export default function Dashboard({
             }}
           >
             <Stack direction="row" spacing={1} alignItems="center">
+              <ImportButton />
+              <ShareButton />
               <ThemeToggleButton />
               <ProfileButton />
             </Stack>

--- a/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
@@ -291,10 +291,21 @@ export default function DashboardDrawer({
 
   const handleDelete = () => {
     if (contextState.type === "group") {
+      const group = userDashboard.find(
+        (group) => group.title === contextState.id,
+      );
+      if (group) {
+        group.items.forEach((item) => {
+          sessionStorage.removeItem(`${item.id}_State`);
+        });
+      }
+
       setUserDashboard((userDashboard) =>
         userDashboard.filter((group) => group.title !== contextState.id),
       );
     } else if (contextState.type === "item") {
+      sessionStorage.removeItem(`${contextState.id}_State`);
+
       setUserDashboard((userDashboard) =>
         userDashboard.map((group) => {
           const newItems = group.items.filter(

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerItemGroup.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerItemGroup.tsx
@@ -91,11 +91,16 @@ export default function DrawerItemGroup({
   // Handle renaming of the group
   const handleGroupRename = () => {
     if (renameValue.trim() === "") return;
-    setUserDashboard((groups) =>
-      groups.map((group) =>
-        group.title === title ? { ...group, title: renameValue } : group,
-      ),
-    );
+    setUserDashboard((groups) => {
+      const count = groups.reduce(
+        (sum, group) => (group.title.startsWith(renameValue) ? sum + 1 : sum),
+        0,
+      );
+      const newTitle = count > 0 ? `${renameValue} (${count})` : renameValue;
+      return groups.map((group) =>
+        group.title === title ? { ...group, title: newTitle } : group,
+      );
+    });
     setRenamingGroupId(null);
     setRenameValue("");
   };

--- a/packages/diracx-web-components/src/components/DashboardLayout/ImportButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ImportButton.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import {
+  IconButton,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+} from "@mui/material";
+import InputIcon from "@mui/icons-material/Input";
+import React, { useState, useContext, SetStateAction } from "react";
+import { ApplicationsContext } from "../../contexts";
+import { ApplicationMetadata, DashboardGroup } from "../../types";
+import { ApplicationState } from "../../types/ApplicationMetadata";
+
+interface ImportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onImport: (state: string) => void;
+}
+
+function ImportDialog({ open, onClose, onImport }: ImportDialogProps) {
+  const [stateText, setStateText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleImport = () => {
+    try {
+      const parsedState = JSON.parse(stateText);
+      onImport(parsedState);
+      onClose();
+      setStateText("");
+      setError(null);
+    } catch {
+      setError("Invalid JSON format");
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle data-testid="import-menu">
+        Import Application State
+      </DialogTitle>
+      <DialogContent>
+        <TextField
+          multiline
+          rows={8}
+          fullWidth
+          value={stateText}
+          onChange={(e) => setStateText(e.target.value)}
+          placeholder="Paste your application state here..."
+          error={!!error}
+          helperText={error}
+          sx={{ mt: 2 }}
+          datatype="import-menu-field"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleImport}
+          variant="contained"
+          disabled={!stateText.trim()}
+        >
+          Import
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/**
+ * ImportButton component allows users to import the state of applications.
+ * It provides a dialog to paste the state in JSON format.
+ */
+export function ImportButton() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [userDashboard, setUserDashboard, appList] =
+    useContext(ApplicationsContext);
+
+  const handleImport = (importedState: ApplicationState) => {
+    const states = Array.isArray(importedState)
+      ? importedState
+      : [importedState];
+
+    const id: number = userDashboard.reduce(
+      (acc, group) =>
+        group.title.startsWith("Imported Applications") ? acc + 1 : acc,
+      0,
+    );
+
+    const newGroup = {
+      title: `Imported Applications${id > 0 ? ` (${id})` : ""}`,
+      extended: true,
+      items: [],
+    };
+
+    userDashboard.push(newGroup);
+
+    states.forEach((state) => {
+      const appMetadata = appList.find((meta) => meta.name === state.appType);
+      if (state.state !== "null" && appMetadata?.setState) {
+        const appId = handleAppCreation(
+          state.appType,
+          appList,
+          userDashboard,
+          setUserDashboard,
+        );
+        appMetadata.setState(appId, state.state);
+      } else {
+        if (state.state === "null")
+          console.warn(`No state to import for app type: ${state.appType}`);
+        else console.warn(`No setState handler for app type: ${state.appType}`);
+      }
+    });
+  };
+
+  return (
+    <>
+      <Tooltip title="Import application state">
+        <IconButton onClick={() => setDialogOpen(true)}>
+          <InputIcon />
+        </IconButton>
+      </Tooltip>
+
+      <ImportDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onImport={handleImport}
+      />
+    </>
+  );
+}
+
+/**
+ * Handles the creation of a new app in the dashboard drawer.
+ *
+ * @param appType - The type of the app to be created.
+ * @param icon - The icon component for the app.
+ */
+function handleAppCreation(
+  appType: string,
+  appList: ApplicationMetadata[],
+  userDashboard: DashboardGroup[],
+  setUserDashboard: React.Dispatch<SetStateAction<DashboardGroup[]>>,
+): string {
+  const group = userDashboard[userDashboard.length - 1];
+
+  let title = `${appType} ${userDashboard.reduce(
+    (sum, group) =>
+      sum + group.items.filter((item) => item.type === appType).length,
+    1,
+  )}`;
+  while (group.items.some((item) => item.title === title)) {
+    title = `${appType} ${parseInt(title.split(" ")[1]) + 1}`;
+  }
+
+  const appId = `${title}${userDashboard.reduce(
+    (sum, group) => sum + group.items.length,
+    0,
+  )}`;
+
+  const newApp = {
+    title,
+    id: appId,
+    type: appType,
+    icon: appList.find((app) => app.name === appType)?.icon || null,
+  };
+  group.items.push(newApp);
+  setUserDashboard((userDashboard) =>
+    userDashboard.map((g) => (g.title === group.title ? group : g)),
+  );
+
+  return appId;
+}

--- a/packages/diracx-web-components/src/components/DashboardLayout/ShareButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ShareButton.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useMemo, useState, useContext } from "react";
+
+import {
+  IconButton,
+  Tooltip,
+  Menu,
+  Typography,
+  Button,
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Checkbox,
+  useTheme,
+  FormControlLabel,
+} from "@mui/material";
+
+import OutputIcon from "@mui/icons-material/Output";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+import { DashboardGroup } from "../../types/DashboardGroup";
+
+import { ApplicationsContext } from "../../contexts";
+
+interface ShareDialogProps {
+  open: boolean;
+  onClose: () => void;
+  state: string;
+}
+
+function ShareDialog({ open, onClose, state }: ShareDialogProps) {
+  const theme = useTheme();
+  const handleCopy = () => {
+    navigator.clipboard.writeText(state);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Application State</DialogTitle>
+      <DialogContent>
+        <Typography
+          variant="body2"
+          component="pre"
+          sx={{
+            whiteSpace: "pre-wrap",
+            wordWrap: "break-word",
+            bgcolor: theme.palette.mode === "light" ? "grey.100" : "grey.800",
+            p: 2,
+            borderRadius: 1,
+          }}
+        >
+          {state}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleCopy}
+          startIcon={<ContentCopyIcon />}
+          variant="contained"
+        >
+          Copy to Clipboard
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/**
+ * ShareButton component allows users to share the state of selected applications.
+ * It provides a menu with checkboxes for each application and a dialog to display the state.
+ */
+export function ShareButton() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedApps, setSelectedApps] = useState<string[]>([]);
+  const [selectedState, setSelectedState] = useState("");
+  const [groups, , appList] = useContext(ApplicationsContext);
+
+  const availableApps: string[] = useMemo(
+    () => appList.map((app) => (app.getState ? app.name : "")),
+    [groups],
+  );
+
+  // Function to handle the click event on the share button
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    setSelectedApps([]); // Reset selection when opening menu
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleAppToggle = (appId: string) => {
+    setSelectedApps((prev) => {
+      if (prev.includes(appId)) {
+        return prev.filter((id) => id !== appId);
+      } else {
+        return [...prev, appId];
+      }
+    });
+  };
+
+  // Function to handle the share action
+  // It collects the state of selected applications and opens the dialog
+  const handleShare = () => {
+    const states = selectedApps.map((appId) => {
+      const app = groups.flatMap((g) => g.items).find((a) => a.id === appId);
+      if (!app) return null;
+
+      const appMetadata = appList.find((meta) => meta.name === app.type);
+
+      return {
+        appType: app.type,
+        state: appMetadata!.getState ? appMetadata!.getState(app.id) : "null",
+      };
+    });
+
+    setSelectedState(JSON.stringify(states, null, 2));
+    setDialogOpen(true);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Tooltip title="Share application state">
+        <IconButton onClick={handleClick}>
+          <OutputIcon />
+        </IconButton>
+      </Tooltip>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        data-testid="export-menu"
+        slotProps={{ paper: { sx: { p: 2 } } }}
+      >
+        {groups.map(
+          (group) =>
+            group.items.some((app) => availableApps.includes(app.type)) && (
+              <div key={group.title}>
+                <FormControlLabel
+                  label={group.title}
+                  control={
+                    <Checkbox
+                      checked={group.items.every((app) =>
+                        selectedApps.includes(app.id),
+                      )}
+                      indeterminate={
+                        group.items.some((app) =>
+                          selectedApps.includes(app.id),
+                        ) &&
+                        !group.items.every((app) =>
+                          selectedApps.includes(app.id),
+                        )
+                      }
+                      onChange={() => {
+                        const allSelected = group.items.every((app) =>
+                          selectedApps.includes(app.id),
+                        );
+                        if (allSelected) {
+                          setSelectedApps((prev) =>
+                            prev.filter(
+                              (id) => !group.items.some((app) => app.id === id),
+                            ),
+                          );
+                        } else {
+                          setSelectedApps((prev) => [
+                            ...prev,
+                            ...group.items.map((app) => app.id),
+                          ]);
+                        }
+                      }}
+                    />
+                  }
+                />
+                <GroupCheckboxSection
+                  group={group}
+                  selectedApps={selectedApps}
+                  handleAppToggle={handleAppToggle}
+                  availableApps={availableApps}
+                />
+              </div>
+            ),
+        )}
+        {selectedApps.length > 0 && (
+          <Box sx={{ p: 1, borderTop: 1, borderColor: "divider" }}>
+            <Button
+              fullWidth
+              variant="contained"
+              onClick={handleShare}
+              startIcon={<OutputIcon />}
+            >
+              Share {selectedApps.length} selected
+            </Button>
+          </Box>
+        )}
+      </Menu>
+
+      <ShareDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        state={selectedState}
+      />
+    </>
+  );
+}
+
+/**
+ *
+ * @param group - The group of applications
+ * @param selectedApps - The list of selected application IDs
+ * @param handleAppToggle - The function to handle toggling the checkbox
+ * @returns A subsection of checkboxes for the applications in the group
+ */
+function GroupCheckboxSection({
+  group,
+  selectedApps,
+  handleAppToggle,
+  availableApps,
+}: {
+  group: DashboardGroup;
+  selectedApps: string[];
+  handleAppToggle: (appId: string) => void;
+  availableApps: string[];
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", ml: 2 }}>
+      {group.items.map(
+        (app) =>
+          availableApps.includes(app.type) && (
+            <FormControlLabel
+              key={app.id}
+              label={app.title}
+              control={
+                <Checkbox
+                  checked={selectedApps.includes(app.id)}
+                  onChange={() => handleAppToggle(app.id)}
+                  size="small"
+                  data-testid={`checkbox-${app.id}`}
+                />
+              }
+            />
+          ),
+      )}
+    </Box>
+  );
+}

--- a/packages/diracx-web-components/src/components/DashboardLayout/ShareButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ShareButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import {
   IconButton,
@@ -79,12 +79,7 @@ export function ShareButton() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedApps, setSelectedApps] = useState<string[]>([]);
   const [selectedState, setSelectedState] = useState("");
-  const [groups, , appList] = useContext(ApplicationsContext);
-
-  const availableApps: string[] = useMemo(
-    () => appList.map((app) => (app.getState ? app.name : "")),
-    [groups],
-  );
+  const [groups, ,] = useContext(ApplicationsContext);
 
   // Function to handle the click event on the share button
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -113,11 +108,11 @@ export function ShareButton() {
       const app = groups.flatMap((g) => g.items).find((a) => a.id === appId);
       if (!app) return null;
 
-      const appMetadata = appList.find((meta) => meta.name === app.type);
-
+      const appState = sessionStorage.getItem(`${appId}_State`);
       return {
         appType: app.type,
-        state: appMetadata!.getState ? appMetadata!.getState(app.id) : "null",
+        appName: app.title,
+        state: typeof appState === "string" ? appState : "null",
       };
     });
 
@@ -143,7 +138,7 @@ export function ShareButton() {
       >
         {groups.map(
           (group) =>
-            group.items.some((app) => availableApps.includes(app.type)) && (
+            group.items.length > 0 && (
               <div key={group.title}>
                 <FormControlLabel
                   label={group.title}
@@ -184,7 +179,6 @@ export function ShareButton() {
                   group={group}
                   selectedApps={selectedApps}
                   handleAppToggle={handleAppToggle}
-                  availableApps={availableApps}
                 />
               </div>
             ),
@@ -223,32 +217,27 @@ function GroupCheckboxSection({
   group,
   selectedApps,
   handleAppToggle,
-  availableApps,
 }: {
   group: DashboardGroup;
   selectedApps: string[];
   handleAppToggle: (appId: string) => void;
-  availableApps: string[];
 }) {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", ml: 2 }}>
-      {group.items.map(
-        (app) =>
-          availableApps.includes(app.type) && (
-            <FormControlLabel
-              key={app.id}
-              label={app.title}
-              control={
-                <Checkbox
-                  checked={selectedApps.includes(app.id)}
-                  onChange={() => handleAppToggle(app.id)}
-                  size="small"
-                  data-testid={`checkbox-${app.id}`}
-                />
-              }
+      {group.items.map((app) => (
+        <FormControlLabel
+          key={app.id}
+          label={app.title}
+          control={
+            <Checkbox
+              checked={selectedApps.includes(app.id)}
+              onChange={() => handleAppToggle(app.id)}
+              size="small"
+              data-testid={`checkbox-${app.id}`}
             />
-          ),
-      )}
+          }
+        />
+      ))}
     </Box>
   );
 }

--- a/packages/diracx-web-components/src/components/DashboardLayout/index.ts
+++ b/packages/diracx-web-components/src/components/DashboardLayout/index.ts
@@ -5,3 +5,5 @@ export { default as DrawerItem } from "./DrawerItem";
 export { default as DrawerItemGroup } from "./DrawerItemGroup";
 export { ProfileButton } from "./ProfileButton";
 export { ThemeToggleButton } from "./ThemeToggleButton";
+export { ShareButton } from "./ShareButton";
+export { ImportButton } from "./ImportButton";

--- a/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
+++ b/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Box } from "@mui/material";
-import { ApplicationState } from "../../types/ApplicationMetadata";
 import { useApplicationId } from "../../hooks/application";
 import { JobDataTable } from "./JobDataTable";
 /**
@@ -24,14 +23,4 @@ export default function JobMonitor() {
       <JobDataTable key={appId} />
     </Box>
   );
-}
-
-export function exportState(appId: string): ApplicationState {
-  const state = sessionStorage.getItem(`${appId}_State`);
-  return state ? state : "null";
-}
-
-export function setState(appId: string, state: ApplicationState) {
-  // Set the state in local storage
-  sessionStorage.setItem(`${appId}_State`, state);
 }

--- a/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
+++ b/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { Box } from "@mui/material";
+import { ApplicationState } from "../../types/ApplicationMetadata";
+import { useApplicationId } from "../../hooks/application";
 import { JobDataTable } from "./JobDataTable";
-
 /**
  * Build the Job Monitor application
  *
  * @returns Job Monitor content
  */
 export default function JobMonitor() {
+  const appId = useApplicationId();
   return (
     <Box
       sx={{
@@ -18,7 +20,18 @@ export default function JobMonitor() {
         overflow: "hidden",
       }}
     >
-      <JobDataTable />
+      {/* The key is used to force a re-render of the component when the appId changes */}
+      <JobDataTable key={appId} />
     </Box>
   );
+}
+
+export function exportState(appId: string): ApplicationState {
+  const state = sessionStorage.getItem(`${appId}_State`);
+  return state ? state : "null";
+}
+
+export function setState(appId: string, state: ApplicationState) {
+  // Set the state in local storage
+  sessionStorage.setItem(`${appId}_State`, state);
 }

--- a/packages/diracx-web-components/src/types/ApplicationMetadata.ts
+++ b/packages/diracx-web-components/src/types/ApplicationMetadata.ts
@@ -7,4 +7,10 @@ export default interface ApplicationMetadata {
   name: string;
   component: ElementType;
   icon: SvgIconComponent;
+  /** Function used to get the state of the app for sharing */
+  getState?: (name: string) => ApplicationState;
+  /** Function used to set the state of the app after an import */
+  setState?: (appId: string, state: ApplicationState) => void;
 }
+
+export type ApplicationState = string;

--- a/packages/diracx-web-components/src/types/ApplicationMetadata.ts
+++ b/packages/diracx-web-components/src/types/ApplicationMetadata.ts
@@ -7,10 +7,6 @@ export default interface ApplicationMetadata {
   name: string;
   component: ElementType;
   icon: SvgIconComponent;
-  /** Function used to get the state of the app for sharing */
-  getState?: (name: string) => ApplicationState;
-  /** Function used to set the state of the app after an import */
-  setState?: (appId: string, state: ApplicationState) => void;
 }
 
 export type ApplicationState = string;

--- a/packages/diracx-web-components/stories/ImportButton.stories.tsx
+++ b/packages/diracx-web-components/stories/ImportButton.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Paper } from "@mui/material";
+import { ThemeProvider } from "../src/contexts/ThemeProvider";
+import { ImportButton } from "../src/components/DashboardLayout/ImportButton";
+
+const meta = {
+  title: "Dashboard Layout/ImportButton",
+  component: ImportButton,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => {
+      return (
+        <ThemeProvider>
+          <Paper sx={{ width: "fit-content" }}>
+            <Story />
+          </Paper>
+        </ThemeProvider>
+      );
+    },
+  ],
+} satisfies Meta<typeof ImportButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/diracx-web-components/stories/ShareButton.stories.tsx
+++ b/packages/diracx-web-components/stories/ShareButton.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Paper } from "@mui/material";
+import { ThemeProvider } from "../src/contexts/ThemeProvider";
+import { ShareButton } from "../src/components/DashboardLayout/ShareButton";
+
+const meta = {
+  title: "Dashboard Layout/ShareButton",
+  component: ShareButton,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => {
+      return (
+        <ThemeProvider>
+          <Paper sx={{ width: "fit-content" }}>
+            <Story />
+          </Paper>
+        </ThemeProvider>
+      );
+    },
+  ],
+} satisfies Meta<typeof ShareButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/diracx-web/test/e2e/shareImportState.ts
+++ b/packages/diracx-web/test/e2e/shareImportState.ts
@@ -1,0 +1,184 @@
+/// <reference types="cypress" />
+
+describe("Export and import app state", () => {
+  beforeEach(() => {
+    cy.session("login", () => {
+      cy.visit("/");
+      //login
+      cy.get('[data-testid="button-login"]').click();
+      cy.get("#login").type("admin@example.com");
+      cy.get("#password").type("password");
+
+      // Find the login button and click on it
+      cy.get("button").click();
+      // Grant access
+      cy.get(":nth-child(1) > form > .dex-btn").click();
+      cy.url().should("include", "/auth");
+    });
+
+    cy.visit(
+      "?dashboard=4dashboard%27%7Eextended%21true%7Eitems%2148s3*5B860795913*7A5A23-%27%29%5D%29%5D*B8+6-BFile+Catalog.%28%27title3%27%7Etype4%5B.BMy+5%27%7Eid6Monitor7%27%29%2C.8Job9*+2A-+1B%21%27%01BA9876543.-*_",
+    );
+  });
+
+  it("export button should be visible", () => {
+    cy.get('[aria-label="Share application state"]')
+      .should("be.visible")
+      .click();
+
+    // Select 2 items to share
+    cy.get('[data-testid="export-menu"]').should("be.visible");
+    cy.get('[data-testid="checkbox-JobMonitor0"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 21"]').click();
+
+    // Share and cancel the export
+    cy.contains("Share 2 selected").should("be.visible").click();
+    cy.contains("Cancel").should("be.visible").click();
+
+    // Select 1 item and share it
+    cy.get('[aria-label="Share application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="export-menu"]').should("be.visible");
+    cy.get('[data-testid="checkbox-JobMonitor0"]').click();
+    cy.contains("Share 1 selected").should("be.visible").click();
+  });
+
+  // Test case to check the copy of the empty state
+  it("should copy the empty state", () => {
+    // Select the Job Monitor app
+    cy.get('[aria-label="Share application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="export-menu"]').should("be.visible");
+    cy.get('[data-testid="checkbox-JobMonitor0"]').click();
+    cy.contains("Share 1 selected").should("be.visible").click();
+
+    // Copy and assert the state
+    cy.window().then((win) => {
+      cy.stub(win.navigator.clipboard, "writeText").as("writeTextStub");
+    });
+
+    cy.contains("Copy").click();
+
+    cy.get("@writeTextStub").should(
+      "have.been.calledOnceWithExactly",
+      '[\n  {\n    "appType": "Job Monitor",\n    "state": "null"\n  }\n]',
+    );
+  });
+
+  // Test case to check the copy of the non-empty state
+  it("should copy a non-empty state", () => {
+    // Open the Job Monitor app
+    cy.visit(
+      "?appId=JobMonitor0&dashboard=4dashboard%27%7Eextended%21true%7Eitems%2148s3*5B860795913*7A5A23-%27%29%5D%29%5D*B8+6-BFile+Catalog.%28%27title3%27%7Etype4%5B.BMy+5%27%7Eid6Monitor7%27%29%2C.8Job9*+2A-+1B%21%27%01BA9876543.-*_",
+    );
+
+    // Select the Job Monitor app
+    cy.get('[aria-label="Share application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="export-menu"]').should("be.visible");
+    cy.get('[data-testid="checkbox-JobMonitor0"]').click();
+    cy.contains("Share 1 selected").should("be.visible").click();
+
+    // Copy and assert the state
+    cy.window().then((win) => {
+      cy.stub(win.navigator.clipboard, "writeText").as("writeTextStub");
+    });
+
+    cy.contains("Copy").click();
+
+    cy.get("@writeTextStub").should(
+      "have.been.calledOnceWithExactly",
+      '[\n  {\n    "appType": "Job Monitor",\n    "state": "{\\"columnVisibility\\":{\\"JobGroup\\":false,\\"JobType\\":false,\\"Owner\\":false,\\"OwnerGroup\\":false,\\"VO\\":false,\\"StartExecTime\\":false,\\"EndExecTime\\":false,\\"UserPriority\\":false},\\"columnPinning\\":{\\"left\\":[\\"JobID\\"],\\"right\\":[]},\\"rowSelection\\":{},\\"pagination\\":{\\"pageIndex\\":0,\\"pageSize\\":25}}"\n  }\n]',
+    );
+  });
+
+  it("should copy multiple states", () => {
+    cy.visit(
+      "?dashboard=6dashboard'~extended!true~items!6As4*7DA9058278214*5B7B24-58378334*')])]*DA+9-DFile+Catalog.('title4'~type5')%2C.6[.DMy+7'~id8*+9MonitorAJobB-+1D!'%01DBA987654.-*_",
+    );
+    // Open:
+    // -My Jobs
+    cy.visit(
+      "?appId=JobMonitor0&dashboard=6dashboard'~extended!true~items!6As4*7DA9058278214*5B7B24-58378334*')])]*DA+9-DFile+Catalog.('title4'~type5')%2C.6[.DMy+7'~id8*+9MonitorAJobB-+1D!'%01DBA987654.-*_",
+    );
+    // -Job Monitor 2
+    cy.visit(
+      "?appId=Job+Monitor+21&dashboard=6dashboard'~extended!true~items!6As4*7DA9058278214*5B7B24-58378334*')])]*DA+9-DFile+Catalog.('title4'~type5')%2C.6[.DMy+7'~id8*+9MonitorAJobB-+1D!'%01DBA987654.-*_",
+    );
+    // -Job Monitoring 3
+    cy.visit(
+      "?appId=Job+Monitor+33&dashboard=6dashboard'~extended!true~items!6As4*7DA9058278214*5B7B24-58378334*')])]*DA+9-DFile+Catalog.('title4'~type5')%2C.6[.DMy+7'~id8*+9MonitorAJobB-+1D!'%01DBA987654.-*_",
+    );
+
+    cy.get('[aria-label="Share application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="export-menu"]').should("be.visible");
+    cy.get('[data-testid="checkbox-JobMonitor0"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 21"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 33"]').click();
+    cy.contains("Share 3 selected").should("be.visible").click();
+
+    cy.contains('"appType": "Job Monitor"');
+  });
+
+  it("should the import button be visible", () => {
+    cy.get('[aria-label="Import application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.contains("Cancel").should("be.visible").click();
+    cy.contains("Paste your application state here...").should("not.exist");
+  });
+
+  it("should not import what's not a valid JSON", () => {
+    cy.get('[aria-label="Import application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.get("#«ra»").type("Houston, we have a problem: this isn't JSON.");
+    cy.get("button").contains("Import").click();
+    cy.contains("Invalid JSON format").should("be.visible");
+  });
+
+  it("should import the empty state", () => {
+    cy.get('[aria-label="Import application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.get("#«ra»").type(
+      '[\n  {\n    "appType": "Job Monitor",\n    "state": "null"\n  }\n]',
+    );
+    cy.get("button").contains("Import").click();
+    cy.contains("Imported Applications").should("not.exist");
+  });
+
+  // Test case to check the import of the non-empty state
+  it("should import the non-empty state", () => {
+    cy.get('[aria-label="Import application state"]')
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.get('[data-testid="import-menu"]').should("be.visible");
+    cy.get("#«ra»").type(
+      `[
+      {
+    "appType": "Job Monitor",
+    "state": "{\\"columnVisibility\\":{\\"JobGroup\\":false,\\"JobType\\":false,\\"Owner\\":false,\\"OwnerGroup\\":false,\\"VO\\":false,\\"StartExecTime\\":false,\\"EndExecTime\\":false,\\"UserPriority\\":false},\\"columnPinning\\":{\\"left\\":[\\"JobID\\"],\\"right\\":[]},\\"rowSelection\\":{},\\"pagination\\":{\\"pageIndex\\":0,\\"pageSize\\":25}}"
+  }
+]`,
+      { parseSpecialCharSequences: false },
+    );
+    cy.get("button").contains("Import").click();
+    cy.contains("Imported Applications").should("be.visible");
+
+    cy.contains("Job Monitor 3").click();
+    cy.get(".MuiTypography-h4").contains("Job Monitor 3");
+    cy.contains("No data or no");
+  });
+});


### PR DESCRIPTION
This PR introduces two new buttons that allows to easily **share** and **import**  application state. These features enable simple and quick exchange of selected applications between users. 
- The **share** button generates a sharable representations of the current application state, which can be copied and sent to others.
- The **import** button allows users to load a previously shared state, restoring the same application configuration