### PR TITLE
feat: move FilterToolbar from DataTable to JobMonitor

### DIFF
--- a/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
+++ b/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
@@ -1,7 +1,31 @@
 "use client";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  blue,
+  orange,
+  grey,
+  green,
+  red,
+  lightBlue,
+  purple,
+  teal,
+  blueGrey,
+  lime,
+  amber,
+} from "@mui/material/colors";
+import { lighten, darken, useTheme, Box } from "@mui/material";
+import {
+  createColumnHelper,
+  ColumnPinningState,
+  RowSelectionState,
+  VisibilityState,
+  PaginationState,
+} from "@tanstack/react-table";
 
-import { Box } from "@mui/material";
 import { useApplicationId } from "../../hooks/application";
+import { FilterToolbar } from "../shared/FilterToolbar";
+import { InternalFilter } from "../../types/Filter";
+import { Job, SearchBody } from "../../types";
 import { JobDataTable } from "./JobDataTable";
 /**
  * Build the Job Monitor application
@@ -10,6 +34,262 @@ import { JobDataTable } from "./JobDataTable";
  */
 export default function JobMonitor() {
   const appId = useApplicationId();
+  const theme = useTheme();
+
+  // Load the initial state from local storage
+  const initialState = sessionStorage.getItem(`${appId}_State`);
+
+  const parsedInitialState =
+    typeof initialState === "string" ? JSON.parse(initialState) : null;
+
+  // State for filters
+  const [filters, setFilters] = useState<InternalFilter[]>(
+    parsedInitialState ? parsedInitialState.filters : [],
+  );
+
+  // State for search body
+  const [searchBody, setSearchBody] = useState<SearchBody>({
+    search: parsedInitialState
+      ? parsedInitialState.filters.map((filter: InternalFilter) => ({
+          parameter: filter.parameter,
+          operator: filter.operator,
+          value: filter.value,
+          values: filter.values,
+        }))
+      : [], // Default to an empty array if no filters are present
+    sort: [{ parameter: "JobID", direction: "desc" }],
+  });
+
+  // States for table settings
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
+    parsedInitialState
+      ? parsedInitialState.columnVisibility
+      : {
+          JobGroup: false,
+          JobType: false,
+          Owner: false,
+          OwnerGroup: false,
+          VO: false,
+          StartExecTime: false,
+          EndExecTime: false,
+          UserPriority: false,
+        },
+  );
+  const [columnPinning, setColumnPinning] = useState<ColumnPinningState>(
+    parsedInitialState
+      ? parsedInitialState.columnPinning
+      : {
+          left: ["JobID"], // Pin JobID column by default
+        },
+  );
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>(
+    parsedInitialState ? parsedInitialState.rowSelection : {},
+  );
+  const [pagination, setPagination] = useState<PaginationState>(
+    parsedInitialState
+      ? parsedInitialState.pagination
+      : {
+          pageIndex: 0,
+          pageSize: 25,
+        },
+  );
+
+  // Save the state of the app in local storage
+  useEffect(() => {
+    const state = {
+      filters: [...filters.filter((filter) => filter.isApplied)],
+      columnVisibility: { ...columnVisibility },
+      columnPinning: {
+        left: [...(columnPinning.left || [])],
+        right: [...(columnPinning.right || [])],
+      },
+      rowSelection: { ...rowSelection },
+      pagination: {
+        pageIndex: pagination.pageIndex,
+        pageSize: pagination.pageSize,
+      },
+    };
+
+    sessionStorage.setItem(`${appId}_State`, JSON.stringify(state));
+  }, [
+    appId,
+    filters,
+    columnVisibility,
+    columnPinning,
+    rowSelection,
+    pagination,
+  ]);
+
+  // Handle the application of filters
+  const handleApplyFilters = () => {
+    // Switch the applied state of the filters
+    setFilters((filters) =>
+      filters.map((filter) => ({ ...filter, isApplied: true })),
+    );
+
+    setSearchBody((prev) => ({
+      ...prev,
+      search: filters.map(({ parameter, operator, value, values }) => ({
+        parameter,
+        operator,
+        value,
+        values,
+      })),
+    }));
+    setPagination((prevState) => ({
+      ...prevState,
+      pageIndex: 0,
+    }));
+  };
+
+  const handleRemoveAllFilters = useCallback(() => {
+    setSearchBody((prevState) => ({
+      ...prevState,
+      search: [],
+    }));
+    setPagination((prevState) => ({
+      ...prevState,
+      pageIndex: 0,
+    }));
+    setFilters([]);
+  }, [setFilters]);
+
+  // Status colors
+  const statusColors: Record<string, string> = useMemo(
+    () => ({
+      Submitting: purple[500],
+      Received: blueGrey[500],
+      Checking: teal[500],
+      Staging: lightBlue[500],
+      Waiting: amber[600],
+      Matched: blue[300],
+      Running: blue[900],
+      Rescheduled: lime[700],
+      Completing: orange[500],
+      Completed: green[300],
+      Done: green[500],
+      Failed: red[500],
+      Stalled: amber[900],
+      Killed: red[900],
+      Deleted: grey[500],
+    }),
+    [],
+  );
+
+  /**
+   * Renders the status cell with colors
+   */
+  const renderStatusCell = useCallback(
+    (status: string) => {
+      return (
+        <Box
+          sx={{
+            display: "inline-block",
+            borderRadius: "10px",
+            padding: "3px 10px",
+            backgroundColor:
+              theme.palette.mode === "light"
+                ? lighten(statusColors[status] ?? "default", 0.1)
+                : darken(statusColors[status] ?? "default", 0.3),
+            color: "white",
+            fontWeight: "bold",
+          }}
+        >
+          {status}
+        </Box>
+      );
+    },
+    [theme, statusColors],
+  );
+
+  const columnHelper = useMemo(() => createColumnHelper<Job>(), []);
+
+  /**
+   * The head cells for the data grid (desktop version)
+   */
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("JobID", {
+        id: "JobID",
+        header: "ID",
+        meta: { type: "number" },
+      }),
+      columnHelper.accessor("Status", {
+        id: "Status",
+        header: "Status",
+        cell: (info) => renderStatusCell(info.getValue()),
+        meta: { type: "category", values: Object.keys(statusColors).sort() },
+      }),
+      columnHelper.accessor("MinorStatus", {
+        id: "MinorStatus",
+        header: "Minor Status",
+      }),
+      columnHelper.accessor("ApplicationStatus", {
+        id: "ApplicationStatus",
+        header: "Application Status",
+      }),
+      columnHelper.accessor("Site", {
+        id: "Site",
+        header: "Site",
+      }),
+      columnHelper.accessor("JobName", {
+        id: "JobName",
+        header: "Name",
+      }),
+      columnHelper.accessor("JobGroup", {
+        id: "JobGroup",
+        header: "Job Group",
+      }),
+      columnHelper.accessor("JobType", {
+        id: "JobType",
+        header: "Type",
+      }),
+      columnHelper.accessor("LastUpdateTime", {
+        id: "LastUpdateTime",
+        header: "Last Update Time",
+        meta: { type: "date" },
+      }),
+      columnHelper.accessor("HeartBeatTime", {
+        id: "HeartBeatTime",
+        header: "Last Sign of Life",
+        meta: { type: "date" },
+      }),
+      columnHelper.accessor("SubmissionTime", {
+        id: "SubmissionTime",
+        header: "Submission Time",
+        meta: { type: "date" },
+      }),
+      columnHelper.accessor("Owner", {
+        id: "Owner",
+        header: "Owner",
+      }),
+      columnHelper.accessor("OwnerGroup", {
+        id: "OwnerGroup",
+        header: "Owner Group",
+      }),
+      columnHelper.accessor("VO", {
+        id: "VO",
+        header: "VO",
+      }),
+      columnHelper.accessor("StartExecTime", {
+        id: "StartExecTime",
+        header: "Start Execution Time",
+        meta: { type: "date" },
+      }),
+      columnHelper.accessor("EndExecTime", {
+        id: "EndExecTime",
+        header: "End Execution Time",
+        meta: { type: "date" },
+      }),
+      columnHelper.accessor("UserPriority", {
+        id: "UserPriority",
+        header: "User Priority",
+        meta: { type: "number" },
+      }),
+    ],
+    [columnHelper, renderStatusCell, statusColors],
+  );
+
   return (
     <Box
       sx={{
@@ -19,8 +299,26 @@ export default function JobMonitor() {
         overflow: "hidden",
       }}
     >
-      {/* The key is used to force a re-render of the component when the appId changes */}
-      <JobDataTable key={appId} />
+      <FilterToolbar
+        columns={columns}
+        filters={filters}
+        setFilters={setFilters}
+        handleApplyFilters={handleApplyFilters}
+        handleClearFilters={handleRemoveAllFilters}
+      />
+      <JobDataTable
+        searchBody={searchBody}
+        setSearchBody={setSearchBody}
+        columns={columns}
+        pagination={pagination}
+        setPagination={setPagination}
+        columnVisibility={columnVisibility}
+        setColumnVisibility={setColumnVisibility}
+        columnPinning={columnPinning}
+        setColumnPinning={setColumnPinning}
+        rowSelection={rowSelection}
+        setRowSelection={setRowSelection}
+      />
     </Box>
   );
 }

--- a/packages/diracx-web-components/src/components/shared/FilterForm.tsx
+++ b/packages/diracx-web-components/src/components/shared/FilterForm.tsx
@@ -13,14 +13,14 @@ import {
 } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { Column } from "@tanstack/react-table";
+import { ColumnDef } from "@tanstack/react-table";
 import dayjs from "dayjs";
 import { InternalFilter } from "../../types/Filter";
 import "dayjs/locale/en-gb"; // needed by LocalizationProvider to format Dates to dd-mm-yyyy
 
 /**
  * Filter form props
- * @property {AccessorKeyColumnDef[]} columns - the columns on which to filter
+ * @property {ColumnDef[]} columns - the columns on which to filter
  * @property {function} handleFilterChange - the function to call when a filter is changed
  * @property {function} handleFilterMenuClose - the function to call when the filter menu is closed
  * @property {InternalFilter[]} filters - the filters for the table
@@ -28,7 +28,8 @@ import "dayjs/locale/en-gb"; // needed by LocalizationProvider to format Dates t
  */
 export interface FilterFormProps<T extends Record<string, unknown>> {
   /** The columns of the data table */
-  columns: Column<T>[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columns: ColumnDef<T, any>[];
   /** The function to call when a filter is changed */
   handleFilterChange: (index: number, tempFilter: InternalFilter) => void;
   /** The function to call when the filter menu is closed */
@@ -68,6 +69,7 @@ export function FilterForm<T extends Record<string, unknown>>({
         parameter: "",
         operator: "eq",
         value: "",
+        isApplied: false,
       });
     }
   }, [filters, filterIndex]);
@@ -99,8 +101,8 @@ export function FilterForm<T extends Record<string, unknown>>({
 
   const selectedColumn = columns.find((c) => c.id == tempFilter.parameter);
 
-  const columnType = selectedColumn?.columnDef.meta?.type || "default";
-  const isCategory = Array.isArray(selectedColumn?.columnDef.meta?.values);
+  const columnType = selectedColumn?.meta?.type || "default";
+  const isCategory = Array.isArray(selectedColumn?.meta?.values);
   const isDateTime = columnType === "date";
   const isNumber = columnType === "number";
 
@@ -237,7 +239,7 @@ export function FilterForm<T extends Record<string, unknown>>({
             multiple={isMultiple}
             sx={{ minWidth: 100 }}
           >
-            {selectedColumn?.columnDef.meta?.values?.map((val: string) => (
+            {selectedColumn?.meta?.values?.map((val: string) => (
               <MenuItem key={val} value={val}>
                 {val}
               </MenuItem>
@@ -300,7 +302,7 @@ export function FilterForm<T extends Record<string, unknown>>({
             onChange("parameter", parameter);
 
             const column = columns.find((v) => v.id === parameter);
-            const colType = column?.columnDef.meta?.type || "default";
+            const colType = column?.meta?.type || "default";
             const typeKey =
               colType === "date"
                 ? "date"
@@ -320,10 +322,10 @@ export function FilterForm<T extends Record<string, unknown>>({
         >
           {columns.map((column) => (
             <MenuItem
-              key={column.id.toString()}
+              key={(column.id ?? "undefined").toString()}
               value={column.id as string | number}
             >
-              {column.columnDef.header?.toString()}
+              {column.header?.toString()}
             </MenuItem>
           ))}
         </Select>

--- a/packages/diracx-web-components/src/components/shared/FilterToolbar.tsx
+++ b/packages/diracx-web-components/src/components/shared/FilterToolbar.tsx
@@ -6,7 +6,7 @@ import { FilterList, Delete, Send, Refresh } from "@mui/icons-material";
 import Chip from "@mui/material/Chip";
 import Button from "@mui/material/Button";
 import { Alert, Box, Popover, Stack, Tooltip } from "@mui/material";
-import { Column } from "@tanstack/react-table";
+import { ColumnDef } from "@tanstack/react-table";
 import { InternalFilter } from "../../types/Filter";
 import { FilterForm } from "./FilterForm";
 import "../../hooks/theme";
@@ -17,13 +17,12 @@ import "../../hooks/theme";
  */
 export interface FilterToolbarProps<T extends Record<string, unknown>> {
   /** The columns of the data table */
-  columns: Column<T>[];
-  /** The filters to apply */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columns: ColumnDef<T, any>[];
+  /** The filters */
   filters: InternalFilter[];
   /** The function to set the filters */
   setFilters: React.Dispatch<React.SetStateAction<InternalFilter[]>>;
-  /** The applied filters */
-  appliedFilters: InternalFilter[];
   /** The function to apply the filters */
   handleApplyFilters: () => void;
   /** The function to remove all filters */
@@ -39,7 +38,6 @@ export function FilterToolbar<T extends Record<string, unknown>>({
   columns,
   filters,
   setFilters,
-  appliedFilters,
   handleApplyFilters,
   handleClearFilters,
 }: FilterToolbarProps<T>) {
@@ -58,6 +56,7 @@ export function FilterToolbar<T extends Record<string, unknown>>({
       parameter: "",
       operator: "eq",
       value: "",
+      isApplied: false,
     };
     setSelectedFilter(newFilter);
     setAnchorEl(addFilterButtonRef.current);
@@ -93,15 +92,8 @@ export function FilterToolbar<T extends Record<string, unknown>>({
   };
 
   const changesUnapplied = useCallback(() => {
-    return JSON.stringify(filters) !== JSON.stringify(appliedFilters);
-  }, [filters, appliedFilters]);
-
-  const isApplied = useCallback(
-    (filter: InternalFilter) => {
-      return appliedFilters.some((f) => f.id == filter.id);
-    },
-    [appliedFilters],
-  );
+    return filters.some((filter) => !filter.isApplied);
+  }, [filters]);
 
   function debounce<T extends (event: KeyboardEvent) => void>(
     func: T,
@@ -214,12 +206,10 @@ export function FilterToolbar<T extends Record<string, unknown>>({
             }}
             sx={{
               m: 0.5,
-              backgroundColor: isApplied(filter) ? "primary.main" : grey[500],
+              backgroundColor: filter.isApplied ? "primary.main" : grey[500],
             }}
             className={
-              isApplied(filter)
-                ? "chip-filter-applied"
-                : "chip-filter-unapplied"
+              filter.isApplied ? "chip-filter-applied" : "chip-filter-unapplied"
             }
           />
         ))}

--- a/packages/diracx-web-components/src/types/DashboardItem.ts
+++ b/packages/diracx-web-components/src/types/DashboardItem.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { SvgIconComponent } from "@mui/icons-material";
-import { InternalFilter } from "./Filter";
 
 // Define the type for the Dashboard Item state
 export interface DashboardItem {
@@ -9,5 +8,4 @@ export interface DashboardItem {
   type: string;
   id: string;
   icon: SvgIconComponent | null;
-  data?: InternalFilter[];
 }

--- a/packages/diracx-web-components/src/types/Filter.ts
+++ b/packages/diracx-web-components/src/types/Filter.ts
@@ -19,4 +19,5 @@ export interface Filter {
  */
 export interface InternalFilter extends Filter {
   id: number;
+  isApplied: boolean;
 }

--- a/packages/diracx-web-components/test/FilterForm.test.tsx
+++ b/packages/diracx-web-components/test/FilterForm.test.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
-import {
-  createColumnHelper,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
+import { createColumnHelper } from "@tanstack/react-table";
 import { FilterForm } from "../src/components/shared/FilterForm";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 
@@ -22,33 +18,37 @@ describe("FilterForm", () => {
 
   const columnDefs = [
     columnHelper.accessor("id", {
+      id: "id",
       header: "ID",
       meta: { type: "number" },
     }),
     columnHelper.accessor("name", {
+      id: "name",
       header: "Name",
       meta: { type: "string" },
     }),
     columnHelper.accessor("category", {
+      id: "category",
       header: "Category",
       meta: { type: "category", values: ["A", "B", "C"] }, // Example of a category column
     }),
     columnHelper.accessor("date", {
+      id: "date",
       header: "Date",
       meta: { type: "date" }, // Example of a DateTime column
     }),
   ];
 
-  // Create mock data for the table
-  const data: SimpleItem[] = [
-    { id: 1, name: "Item 1", category: "A", date: new Date() },
-    { id: 2, name: "Item 2", category: "B", date: new Date() },
-  ];
-
   // Mock filters
   const filters = [
-    { id: 1, parameter: "id", operator: "eq", value: "4" },
-    { id: 2, parameter: "name", operator: "neq", value: "value2" },
+    { id: 1, parameter: "id", operator: "eq", value: "4", isApplied: false },
+    {
+      id: 2,
+      parameter: "name",
+      operator: "neq",
+      value: "value2",
+      isApplied: false,
+    },
   ];
   const setFilters = jest.fn();
   const handleFilterChange = jest.fn();
@@ -62,16 +62,10 @@ describe("FilterForm", () => {
   const FilterFormWrapper: React.FC<FilterFormWrapperProps> = ({
     selectedFilterId,
   }) => {
-    const table = useReactTable<SimpleItem>({
-      data,
-      columns: columnDefs,
-      getCoreRowModel: getCoreRowModel(),
-    });
-
     return (
       <ThemeProvider>
         <FilterForm<SimpleItem>
-          columns={table.getAllColumns()}
+          columns={columnDefs}
           filters={filters}
           setFilters={setFilters}
           handleFilterChange={handleFilterChange}
@@ -150,7 +144,13 @@ describe("FilterForm", () => {
 
     expect(setFilters).toHaveBeenCalledWith([
       ...filters,
-      { id: expect.any(Number), parameter: "", operator: "eq", value: "" },
+      {
+        id: expect.any(Number),
+        parameter: "",
+        operator: "eq",
+        value: "",
+        isApplied: false,
+      },
     ]);
     expect(handleFilterChange).not.toHaveBeenCalled();
     expect(handleFilterMenuClose).toHaveBeenCalled();
@@ -178,6 +178,7 @@ describe("FilterForm", () => {
       parameter: "category",
       operator: "eq",
       value: "",
+      isApplied: false,
     });
     expect(handleFilterMenuClose).toHaveBeenCalled();
   });

--- a/packages/diracx-web-components/test/FilterToolbar.test.tsx
+++ b/packages/diracx-web-components/test/FilterToolbar.test.tsx
@@ -42,12 +42,22 @@ describe("FilterToolbar", () => {
 
   // Create mock filters
   const filters = [
-    { id: 1, parameter: "id", operator: "eq", value: "value1" },
-    { id: 2, parameter: "name", operator: "neq", value: "value2" },
+    {
+      id: 1,
+      parameter: "id",
+      operator: "eq",
+      value: "value1",
+      isApplied: true,
+    },
+    {
+      id: 2,
+      parameter: "name",
+      operator: "neq",
+      value: "value2",
+      isApplied: false,
+    },
   ];
-  const appliedFilters = [
-    { id: 1, parameter: "id", operator: "eq", value: "value1" },
-  ];
+
   const setFilters = jest.fn();
   const handleApplyFilters = jest.fn();
   const handleClearFilters = jest.fn();
@@ -68,7 +78,6 @@ describe("FilterToolbar", () => {
           setFilters={setFilters}
           handleApplyFilters={handleApplyFilters}
           handleClearFilters={handleClearFilters}
-          appliedFilters={appliedFilters}
         />
       </ThemeProvider>
     );
@@ -104,19 +113,14 @@ describe("FilterToolbar", () => {
 
     expect(warningMessage).toBeInTheDocument();
 
-    appliedFilters.push({
-      id: 2,
-      parameter: "name",
-      operator: "neq",
-      value: "value2",
-    });
+    filters[1].isApplied = true;
 
     cleanup();
 
     render(<FilterToolbarWrapper />);
 
     expect(warningMessage).not.toBeInTheDocument();
-    appliedFilters.pop();
+    filters[1].isApplied = false;
   });
 
   it("opens the filter form when 'Add filter' button is clicked", () => {

--- a/packages/diracx-web-components/test/JobDataTable.test.tsx
+++ b/packages/diracx-web-components/test/JobDataTable.test.tsx
@@ -1,80 +1,146 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import useSWR from "swr";
-import { useOidcAccessToken } from "@axa-fr/react-oidc";
 import { VirtuosoMockContext } from "react-virtuoso";
+import { useOidcAccessToken } from "@axa-fr/react-oidc";
+import { createColumnHelper } from "@tanstack/react-table";
 import { JobDataTable } from "../src/components/JobMonitor/JobDataTable";
+import { useJobs } from "../src/components/JobMonitor/JobDataService";
+import { Job } from "../src/types";
 
-// Mock modules
+// ——— Mock out OIDC + DataService hooks/funcs ———
 jest.mock("@axa-fr/react-oidc", () => ({
   useOidcAccessToken: jest.fn(),
 }));
 
-jest.mock("swr", () => jest.fn());
-
-// In your test file or a Jest setup file
-jest.mock("jsoncrush", () => ({
-  crush: jest.fn().mockImplementation((data) => `crushed-${data}`),
-  uncrush: jest.fn().mockImplementation((data) => data.replace("crushed-", "")),
+jest.mock("../src/components/JobMonitor/JobDataService", () => ({
+  useJobs: jest.fn(),
+  deleteJobs: jest.fn(),
+  killJobs: jest.fn(),
+  rescheduleJobs: jest.fn(),
+  refreshJobs: jest.fn(),
+  getJobHistory: jest.fn(),
 }));
 
+const columnHelper = createColumnHelper<Job>();
+
+const columnDefs = [
+  columnHelper.accessor("JobID", {
+    id: "JobID",
+    header: "Job ID",
+    meta: { type: "string" },
+  }),
+  columnHelper.accessor("JobName", {
+    id: "JobName",
+    header: "Job Name",
+    meta: { type: "string" },
+  }),
+  columnHelper.accessor("Status", {
+    id: "Status",
+    header: "Status",
+    meta: { type: "string" },
+  }),
+  columnHelper.accessor("MinorStatus", {
+    id: "MinorStatus",
+    header: "Minor Status",
+    meta: { type: "string" },
+  }),
+  columnHelper.accessor("SubmissionTime", {
+    id: "SubmissionTime",
+    header: "Submission Time",
+    meta: { type: "date" },
+  }),
+];
+
+const defaultProps = {
+  searchBody: {
+    search: [],
+    sort: [{ parameter: "JobID", direction: "desc" as const }],
+  },
+  setSearchBody: jest.fn(),
+  columns: columnDefs,
+  pagination: { pageIndex: 0, pageSize: 25 },
+  setPagination: jest.fn(),
+  rowSelection: {},
+  setRowSelection: jest.fn(),
+  columnVisibility: {},
+  setColumnVisibility: jest.fn(),
+  columnPinning: { left: [] },
+  setColumnPinning: jest.fn(),
+};
+
 describe("<JobDataTable />", () => {
-  it("displays loading state when data is being validated", () => {
-    (useSWR as jest.Mock).mockReturnValue({
-      data: null,
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // return shape matching: const { accessToken } = useOidcAccessToken(...)
+    (useOidcAccessToken as jest.Mock).mockReturnValue({ accessToken: "1234" });
+  });
+
+  function renderWithProps(overrides = {}) {
+    return render(
+      <VirtuosoMockContext.Provider
+        value={{ viewportHeight: 300, itemHeight: 100 }}
+      >
+        <JobDataTable {...defaultProps} {...overrides} />
+      </VirtuosoMockContext.Provider>,
+    );
+  }
+
+  it("displays the skeleton when `isValidating` is true", () => {
+    (useJobs as jest.Mock).mockReturnValue({
+      data: undefined,
       error: null,
       isValidating: true,
       isLoading: false,
     });
-    (useOidcAccessToken as jest.Mock).mockReturnValue("1234");
 
-    const { getByTestId } = render(<JobDataTable />);
+    const { getByTestId } = renderWithProps();
     expect(getByTestId("loading-skeleton")).toBeVisible();
   });
 
-  it("displays loading state when data is being loaded", () => {
-    (useSWR as jest.Mock).mockReturnValue({
-      data: null,
+  it("displays the skeleton when `isLoading` is true", () => {
+    (useJobs as jest.Mock).mockReturnValue({
+      data: undefined,
       error: null,
       isValidating: false,
       isLoading: true,
     });
-    (useOidcAccessToken as jest.Mock).mockReturnValue("1234");
 
-    const { getByTestId } = render(<JobDataTable />);
+    const { getByTestId } = renderWithProps();
     expect(getByTestId("loading-skeleton")).toBeVisible();
   });
 
-  it("displays error state", () => {
-    (useSWR as jest.Mock).mockReturnValue({
-      data: null,
-      error: true,
+  it("displays the error message", () => {
+    (useJobs as jest.Mock).mockReturnValue({
+      data: undefined,
+      error: new Error("fetch-fail"),
       isValidating: false,
       isLoading: false,
     });
 
-    const { getByText } = render(<JobDataTable />);
+    const { getByText } = renderWithProps();
     expect(
       getByText("An error occurred while fetching data. Reload the page."),
     ).toBeInTheDocument();
   });
 
-  it("displays no jobs data state", () => {
-    (useSWR as jest.Mock).mockReturnValue({
-      data: [],
-      error: false,
+  it("displays the no-data message when `data.data` is empty", () => {
+    (useJobs as jest.Mock).mockReturnValue({
+      data: { headers: new Headers(), data: [] },
+      error: null,
       isValidating: false,
       isLoading: false,
     });
 
-    const { getByText } = render(<JobDataTable />);
+    const { getByText } = renderWithProps();
     expect(
       getByText("No data or no results match your filters."),
     ).toBeInTheDocument();
   });
 
-  it("displays jobs data in the grid", () => {
-    const mockData = {
+  it("renders rows when there is job data", () => {
+    const headers = new Headers({ "content-range": "jobs 0-0/1" });
+    const fakeData = {
+      headers,
       data: [
         {
           JobID: "1",
@@ -85,22 +151,15 @@ describe("<JobDataTable />", () => {
         },
       ],
     };
-    (useSWR as jest.Mock).mockReturnValue({
-      data: mockData,
-      error: false,
+
+    (useJobs as jest.Mock).mockReturnValue({
+      data: fakeData,
+      error: null,
       isValidating: false,
       isLoading: false,
     });
 
-    const { getByText } = render(<JobDataTable />, {
-      wrapper: ({ children }) => (
-        <VirtuosoMockContext.Provider
-          value={{ viewportHeight: 300, itemHeight: 100 }}
-        >
-          {children}
-        </VirtuosoMockContext.Provider>
-      ),
-    });
+    const { getByText } = renderWithProps();
     expect(getByText("TestJob1")).toBeInTheDocument();
   });
 });

--- a/packages/diracx-web/src/app/(dashboard)/page.tsx
+++ b/packages/diracx-web/src/app/(dashboard)/page.tsx
@@ -23,5 +23,5 @@ export default function Page() {
     return applicationList.find((app) => app.name === appType)?.component;
   }, [appType]);
 
-  return Component ? <Component /> : <BaseApp />;
+  return Component ? <Component key={appId} /> : <BaseApp />;
 }

--- a/packages/extensions/src/app/(dashboard)/page.tsx
+++ b/packages/extensions/src/app/(dashboard)/page.tsx
@@ -26,5 +26,5 @@ export default function Page() {
   }, [appType]);
 
   // Render the component if it exists, otherwise render the UserDashboard
-  return Component ? <Component /> : <BaseApp />;
+  return Component ? <Component key={appId} /> : <BaseApp />;
 }


### PR DESCRIPTION
- DataTable becomes more generic and reusable in different contexts
- Moving FilterToolbar allows preparing the pie chart view in the `JobMonitoring` app