### PR TITLE
build: link stories to unit test to track changes

### DIFF
--- a/docs/developer/contribute.md
+++ b/docs/developer/contribute.md
@@ -20,10 +20,9 @@
 
 - **Testing**:
 
-  - **Component Testing**: Write tests for your components to ensure they work as expected. Use [Jest](https://jestjs.io/) for unit testing and snapshot testing of your React components.
+  - **Component Testing**: Write tests for your stories to ensure they work as expected. Use [Jest](https://jestjs.io/) for unit testing and snapshot testing of your React components.
   - **Application Testing**: Use [Cypress](https://www.cypress.io/) for end-to-end testing to simulate real user interactions and ensure your application behaves correctly.
   - **Test Coverage**: Maintain good test coverage to ensure that your critical features are well-protected during updates. Tools like Jest provide [coverage reports](https://jestjs.io/docs/code-coverage) that help you identify untested parts of your code.
-
 
 - **Accessibility**: Make your application accessible to all users. Use semantic HTML, ARIA attributes, and test your application with different screen sizes and assistive technologies.
 

--- a/packages/diracx-web-components/.storybook/main.ts
+++ b/packages/diracx-web-components/.storybook/main.ts
@@ -37,13 +37,10 @@ const config: StorybookConfig = {
     config.resolve.alias = {
       ...config.resolve.alias,
       "@axa-fr/react-oidc": require.resolve(
-        "../stories/mocks/react-oidc.mock.ts",
+        "../stories/mocks/react-oidc.mock.tsx",
       ),
-      "@actual/react-oidc": require.resolve("@axa-fr/react-oidc"),
-
-      "@actual/hooks/metadata$": require.resolve("../src/hooks/metadata"),
       "../../hooks/metadata": require.resolve(
-        "../stories/mocks/metadata.mock.ts",
+        "../stories/mocks/metadata.mock.tsx",
       ),
 
       "@actual/components/JobMonitor/JobDataService$": require.resolve(

--- a/packages/diracx-web-components/jest.config.js
+++ b/packages/diracx-web-components/jest.config.js
@@ -9,6 +9,11 @@ const config = {
 
   // The test environment that will be used for testing
   testEnvironment: "jest-environment-jsdom",
+
+  moduleNameMapper: {
+    "^@axa-fr/react-oidc$": "<rootDir>/stories/mocks/react-oidc.mock.tsx",
+    "^src/hooks/metadata$": "<rootDir>/stories/mocks/metadata.mock.tsx",
+  },
 };
 
 export default config;

--- a/packages/diracx-web-components/jest.setup.ts
+++ b/packages/diracx-web-components/jest.setup.ts
@@ -1,1 +1,3 @@
 import "@testing-library/jest-dom";
+
+jest.mock("@axa-fr/react-oidc");

--- a/packages/diracx-web-components/src/components/BaseApp/BaseApp.tsx
+++ b/packages/diracx-web-components/src/components/BaseApp/BaseApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useOidcAccessToken } from "@axa-fr/react-oidc/";
+import { useOidcAccessToken } from "@axa-fr/react-oidc";
 import { useOIDCContext } from "../../hooks/oidcConfiguration";
 
 /**

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerItem.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerItem.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
   TextField,
 } from "@mui/material";
-import { DragIndicator } from "@mui/icons-material";
+import { DragIndicator, SvgIconComponent } from "@mui/icons-material";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
   draggable,
@@ -23,14 +23,15 @@ import {
   extractClosestEdge,
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import EggIcon from "@mui/icons-material/Egg";
 import { ThemeProvider } from "../../contexts/ThemeProvider";
 import { useSearchParamsUtils } from "../../hooks/searchParamsUtils";
 import { useApplicationId } from "../../hooks/application";
-import { DashboardGroup } from "../../types";
+import { DashboardGroup, DashboardItem } from "../../types";
 
 interface DrawerItemProps {
   /** The item object containing the title, id, and icon. */
-  item: { title: string; id: string; icon: React.ComponentType };
+  item: DashboardItem;
   /** The index of the item. */
   index: number;
   /** The title of the group. */
@@ -53,7 +54,7 @@ interface DrawerItemProps {
  * @returns The rendered JSX for the drawer item.
  */
 export default function DrawerItem({
-  item: { title, id, icon },
+  item,
   index,
   groupTitle,
   renamingItemId,
@@ -100,7 +101,7 @@ export default function DrawerItem({
                       width: source.element.getBoundingClientRect().width,
                     }}
                   >
-                    <ItemPreview title={title} icon={icon} />
+                    <ItemPreview title={item.title} icon={item.icon} />
                   </div>
                 </ThemeProvider>,
               );
@@ -136,9 +137,9 @@ export default function DrawerItem({
           const sourceIndex = source.data.index;
           if (typeof sourceIndex === "number") {
             const isItemBeforeSource =
-              index === sourceIndex - 1 && source.data.title === title;
+              index === sourceIndex - 1 && source.data.title === item.title;
             const isItemAfterSource =
-              index === sourceIndex + 1 && source.data.title === title;
+              index === sourceIndex + 1 && source.data.title === item.title;
 
             const isDropIndicatorHidden =
               (isItemBeforeSource && closestEdge === "bottom") ||
@@ -159,7 +160,7 @@ export default function DrawerItem({
         },
       }),
     );
-  }, [index, groupTitle, icon, theme, title, id]);
+  }, [index, groupTitle, item, theme]);
 
   // Handle renaming of the item
   const handleItemRename = () => {
@@ -169,8 +170,8 @@ export default function DrawerItem({
         if (group.title === groupTitle) {
           return {
             ...group,
-            items: group.items.map((item) =>
-              item.id === id ? { ...item, title: renameValue } : item,
+            items: group.items.map((i) =>
+              i.id === item.id ? { ...item, title: renameValue } : i,
             ),
           };
         }
@@ -185,16 +186,16 @@ export default function DrawerItem({
     <>
       <ListItemButton
         disableGutters
-        key={title}
-        onClick={() => setParam("appId", id)}
+        key={item.title}
+        onClick={() => setParam("appId", item.id)}
         sx={{ pl: 2, borderRadius: 2, pr: 1 }}
         ref={dragRef}
-        selected={appId === id}
+        selected={appId === item.id}
       >
         <ListItemIcon>
-          <Icon component={icon} />
+          <Icon component={item.icon ?? EggIcon} />
         </ListItemIcon>
-        {renamingItemId === id ? (
+        {renamingItemId === item.id ? (
           <TextField
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
@@ -211,7 +212,7 @@ export default function DrawerItem({
           />
         ) : (
           <ListItemText
-            primary={title}
+            primary={item.title}
             sx={{
               whiteSpace: "nowrap",
               overflow: "hidden",
@@ -239,7 +240,7 @@ export default function DrawerItem({
  *
  * @param {Object} props - The component props.
  * @param {string} props.title - The title of the item.
- * @param {React.ComponentType} props.icon - The icon component for the item.
+ * @param {SvgIconComponent} props.icon - The icon component for the item.
  * @returns {JSX.Element} The rendered item preview.
  */
 function ItemPreview({
@@ -247,7 +248,7 @@ function ItemPreview({
   icon,
 }: {
   title: string;
-  icon: React.ComponentType;
+  icon: SvgIconComponent | null;
 }) {
   return (
     <ListItemButton
@@ -261,7 +262,7 @@ function ItemPreview({
       }}
     >
       <ListItemIcon>
-        <Icon component={icon} />
+        <Icon component={icon ?? EggIcon} />
       </ListItemIcon>
       <ListItemText
         primary={title}

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerItemGroup.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerItemGroup.tsx
@@ -6,7 +6,7 @@ import {
   AccordionSummary,
   TextField,
 } from "@mui/material";
-import { ExpandMore, Apps } from "@mui/icons-material";
+import { ExpandMore } from "@mui/icons-material";
 import React, { useEffect, useRef, useState } from "react";
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { DashboardGroup } from "../../types/DashboardGroup";
@@ -139,10 +139,10 @@ export default function DrawerItemGroup({
       </AccordionSummary>
       {/* Accordion details */}
       <AccordionDetails>
-        {items.map(({ title: itemTitle, id, icon }, index) => (
-          <div onContextMenu={handleContextMenu("item", id)} key={id}>
+        {items.map((item, index) => (
+          <div onContextMenu={handleContextMenu("item", item.id)} key={item.id}>
             <DrawerItem
-              item={{ title: itemTitle, id, icon: icon || Apps }}
+              item={item}
               index={index}
               groupTitle={title}
               renamingItemId={renamingItemId}

--- a/packages/diracx-web-components/stories/ApplicationDialog.stories.tsx
+++ b/packages/diracx-web-components/stories/ApplicationDialog.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { useArgs } from "@storybook/core/preview-api";
@@ -7,7 +6,6 @@ import { ApplicationsContext } from "../src/contexts/ApplicationsProvider";
 import { applicationList } from "../src/components/ApplicationList";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import ApplicationDialog from "../src/components/DashboardLayout/ApplicationDialog";
-import { useOidcAccessToken } from "./mocks/react-oidc.mock";
 
 const meta = {
   title: "Dashboard Layout/ApplicationDialog",
@@ -37,13 +35,7 @@ const meta = {
       );
     },
   ],
-  async beforeEach() {
-    useOidcAccessToken.mockReturnValue({
-      accessToken: "123456789",
-      accessTokenPayload: { preferred_username: "John Doe" },
-    });
-    return () => useOidcAccessToken.mockReset();
-  },
+  async beforeEach() {},
 } satisfies Meta<typeof ApplicationDialog>;
 
 export default meta;

--- a/packages/diracx-web-components/stories/BaseApp.stories.tsx
+++ b/packages/diracx-web-components/stories/BaseApp.stories.tsx
@@ -6,7 +6,6 @@ import { ApplicationsContext } from "../src/contexts/ApplicationsProvider";
 import { NavigationProvider } from "../src/contexts/NavigationProvider";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import BaseApp from "../src/components/BaseApp/BaseApp";
-import { useOidcAccessToken } from "./mocks/react-oidc.mock";
 
 const meta = {
   title: "Base Application",
@@ -60,32 +59,15 @@ const meta = {
       </NavigationProvider>
     ),
   ],
-  async beforeEach() {
-    return () => {
-      useOidcAccessToken.mockRestore();
-    };
-  },
+  async beforeEach() {},
 } satisfies Meta<typeof BaseApp>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const LoggedIn: Story = {
+export const Default: Story = {
   args: {},
   render: (props) => {
-    useOidcAccessToken.mockReturnValue({
-      accessTokenPayload: { preferred_username: "John Doe" },
-    });
-    return <BaseApp {...props} />;
-  },
-};
-
-export const LoggedOff: Story = {
-  args: {},
-  render: (props) => {
-    useOidcAccessToken.mockReturnValue({
-      accessTokenPayload: null,
-    });
     return <BaseApp {...props} />;
   },
 };

--- a/packages/diracx-web-components/stories/Dashboard.stories.tsx
+++ b/packages/diracx-web-components/stories/Dashboard.stories.tsx
@@ -8,7 +8,7 @@ import { NavigationProvider } from "../src/contexts/NavigationProvider";
 import { applicationList } from "../src/components/ApplicationList";
 import { DashboardGroup } from "../src/types/DashboardGroup";
 import Dashboard from "../src/components/DashboardLayout/Dashboard";
-import { useOidc, useOidcAccessToken } from "./mocks/react-oidc.mock";
+import { ThemeProvider } from "../src/contexts/ThemeProvider";
 
 const meta = {
   title: "Dashboard Layout/Dashboard",
@@ -50,21 +50,17 @@ const meta = {
           <ApplicationsContext.Provider
             value={[userDashboard, setUserDashboard, applicationList]}
           >
-            <Box sx={{ height: "50vh" }}>
-              <Story />
-            </Box>
+            <ThemeProvider>
+              <Box sx={{ height: "50vh" }}>
+                <Story />
+              </Box>
+            </ThemeProvider>
           </ApplicationsContext.Provider>
         </NavigationProvider>
       );
     },
   ],
-  async beforeEach() {
-    useOidcAccessToken.mockReturnValue({
-      accessToken: "123456789",
-      accessTokenPayload: { preferred_username: "John Doe" },
-    });
-    return () => useOidcAccessToken.mockReset();
-  },
+  async beforeEach() {},
 } satisfies Meta<typeof Dashboard>;
 
 export default meta;
@@ -76,13 +72,11 @@ export const Default: Story = {
     children: <div></div>,
     logoURL: process.env.STORYBOOK_DEV
       ? undefined
-      : "/diracx-web/DIRAC-logo.png", // we need to add "/diracx-web" at the start of the url in production because of the repo name in the github pages url
+      : // we need to add "/diracx-web" at the start of the url in production
+        // because of the repo name in the github pages url
+        "/diracx-web/DIRAC-logo.png",
   },
   render: (props) => {
-    useOidc.mockReturnValue({
-      login: () => {},
-      isAuthenticated: true,
-    });
     return <Dashboard {...props} />;
   },
 };

--- a/packages/diracx-web-components/stories/DashboardDrawer.stories.tsx
+++ b/packages/diracx-web-components/stories/DashboardDrawer.stories.tsx
@@ -8,7 +8,6 @@ import { applicationList } from "../src/components/ApplicationList";
 import { DashboardGroup } from "../src/types";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import DashboardDrawer from "../src/components/DashboardLayout/DashboardDrawer";
-import { useOidc, useOidcAccessToken } from "./mocks/react-oidc.mock";
 
 const meta = {
   title: "Dashboard Layout/DashboardDrawer",
@@ -46,17 +45,7 @@ const meta = {
       );
     },
   ],
-  async beforeEach() {
-    useOidcAccessToken.mockReturnValue({
-      accessToken: "123456789",
-      accessTokenPayload: { preferred_username: "John Doe" },
-    });
-    useOidc.mockReturnValue({
-      login: () => {},
-      isAuthenticated: true,
-    });
-    return () => useOidcAccessToken.mockReset();
-  },
+  async beforeEach() {},
 } satisfies Meta<typeof DashboardDrawer>;
 
 export default meta;

--- a/packages/diracx-web-components/stories/DataTable.stories.tsx
+++ b/packages/diracx-web-components/stories/DataTable.stories.tsx
@@ -43,6 +43,12 @@ const DataTableWrapper: React.FC<Omit<DataTableProps<SimpleItem>, "table">> = (
     data,
     columns: columnDefs,
     getCoreRowModel: getCoreRowModel(),
+    state: {
+      pagination: {
+        pageIndex: 0,
+        pageSize: 25,
+      },
+    },
   });
 
   return <DataTable<SimpleItem> {...props} table={table} />;
@@ -70,7 +76,7 @@ const meta: Meta = {
   decorators: [
     (Story) => (
       <ThemeProvider>
-        <div style={{ width: "900px" }}>
+        <div style={{ width: "900px", height: "500px" }}>
           <Story />
         </div>
       </ThemeProvider>

--- a/packages/diracx-web-components/stories/DrawerItem.stories.tsx
+++ b/packages/diracx-web-components/stories/DrawerItem.stories.tsx
@@ -5,7 +5,6 @@ import { Paper } from "@mui/material";
 import { Dashboard } from "@mui/icons-material";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import DrawerItem from "../src/components/DashboardLayout/DrawerItem";
-import { useOidc, useOidcAccessToken } from "./mocks/react-oidc.mock";
 
 const meta = {
   title: "Dashboard Layout/DrawerItem",
@@ -25,17 +24,7 @@ const meta = {
       );
     },
   ],
-  async beforeEach() {
-    useOidcAccessToken.mockReturnValue({
-      accessToken: "123456789",
-      accessTokenPayload: { preferred_username: "John Doe" },
-    });
-    useOidc.mockReturnValue({
-      login: () => {},
-      isAuthenticated: true,
-    });
-    return () => useOidcAccessToken.mockReset();
-  },
+  async beforeEach() {},
 } satisfies Meta<typeof DrawerItem>;
 
 export default meta;
@@ -48,8 +37,14 @@ export const Default: Story = {
     index: 0,
     item: {
       title: "Dashboard",
+      type: "dashboard",
       id: "Dashboard 1",
       icon: Dashboard,
     },
+    renamingItemId: null,
+    setRenamingItemId: () => {},
+    renameValue: "",
+    setRenameValue: () => {},
+    setUserDashboard: () => {},
   },
 };

--- a/packages/diracx-web-components/stories/DrawerItemGroup.stories.tsx
+++ b/packages/diracx-web-components/stories/DrawerItemGroup.stories.tsx
@@ -6,7 +6,6 @@ import { Dashboard } from "@mui/icons-material";
 import { DashboardGroup } from "../src/types/DashboardGroup";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import DrawerItemGroup from "../src/components/DashboardLayout/DrawerItemGroup";
-import { useOidc, useOidcAccessToken } from "./mocks/react-oidc.mock";
 
 const meta = {
   title: "Dashboard Layout/DrawerItemGroup",
@@ -26,17 +25,7 @@ const meta = {
       );
     },
   ],
-  async beforeEach() {
-    useOidcAccessToken.mockReturnValue({
-      accessToken: "123456789",
-      accessTokenPayload: { preferred_username: "John Doe" },
-    });
-    useOidc.mockReturnValue({
-      login: () => {},
-      isAuthenticated: true,
-    });
-    return () => useOidcAccessToken.mockReset();
-  },
+  async beforeEach() {},
 } satisfies Meta<typeof DrawerItemGroup>;
 
 export default meta;
@@ -59,6 +48,12 @@ export const Default: Story = {
     },
     handleContextMenu: () => () => {},
     setUserDashboard: () => {},
+    renamingGroupId: null,
+    setRenamingGroupId: () => {},
+    renamingItemId: null,
+    setRenamingItemId: () => {},
+    renameValue: "",
+    setRenameValue: () => {},
   },
   render: (props) => {
     const [, updateArgs] = useArgs();

--- a/packages/diracx-web-components/stories/FilterForm.stories.tsx
+++ b/packages/diracx-web-components/stories/FilterForm.stories.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
 import { Paper } from "@mui/material";
-import {
-  createColumnHelper,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
+import { createColumnHelper } from "@tanstack/react-table";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import {
   FilterForm,
@@ -23,33 +19,26 @@ const columnHelper = createColumnHelper<SimpleItem>();
 const columnDefs = [
   columnHelper.accessor("id", {
     header: "ID",
+    id: "id",
     meta: { type: "number" },
   }),
   columnHelper.accessor("name", {
     header: "Name",
+    id: "name",
     meta: { type: "string" },
   }),
   columnHelper.accessor("email", {
     header: "Email",
+    id: "email",
     meta: { type: "string" },
   }),
-];
-
-const data: SimpleItem[] = [
-  { id: 1, name: "John Doe", email: "john@example.com" },
 ];
 
 // Wrapper component to initialize the table
 const FilterFormWrapper: React.FC<
   Omit<FilterFormProps<SimpleItem>, "columns">
 > = (props) => {
-  const table = useReactTable<SimpleItem>({
-    data,
-    columns: columnDefs,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
-  return <FilterForm<SimpleItem> {...props} columns={table.getAllColumns()} />;
+  return <FilterForm<SimpleItem> {...props} columns={columnDefs} />;
 };
 
 const meta = {
@@ -89,7 +78,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    filters: [{ id: 0, parameter: "id", operator: "eq", value: "1" }],
+    filters: [
+      { id: 0, parameter: "id", operator: "eq", value: "1", isApplied: false },
+    ],
     setFilters: () => {},
     handleFilterChange: () => {},
     handleFilterMenuClose: () => {},

--- a/packages/diracx-web-components/stories/LoginForm.stories.tsx
+++ b/packages/diracx-web-components/stories/LoginForm.stories.tsx
@@ -1,10 +1,12 @@
-import React from "react";
 import { StoryObj, Meta } from "@storybook/react";
 import { Paper } from "@mui/material";
 import { ThemeProvider } from "../src/contexts/ThemeProvider";
 import { LoginForm } from "../src/components/Login/LoginForm";
 import { useMetadata } from "./mocks/metadata.mock";
-import { useOidc } from "./mocks/react-oidc.mock";
+import {
+  singleVOMetadata,
+  multiVOMetadata,
+} from "./mocks/metadata.fixtures.mock";
 
 const meta = {
   title: "Login/LoginForm",
@@ -15,12 +17,6 @@ const meta = {
   tags: ["autodocs"],
   argTypes: {
     logoURL: { control: "text" },
-  },
-  beforeEach: async () => {
-    useOidc.mockReturnValue({
-      login: () => {},
-      isAuthenticated: false,
-    });
   },
   decorators: [
     (Story) => {
@@ -43,67 +39,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const singleVOMetadata = {
-  virtual_organizations: {
-    DTeam: {
-      groups: {
-        admin: {
-          properties: ["AdminUser"],
-        },
-        user: {
-          properties: ["NormalUser"],
-        },
-      },
-      support: {
-        message: "Please contact system administrator",
-        webpage: null,
-        email: null,
-      },
-      default_group: "user",
-    },
-  },
-};
-
-const multiVOMetadata = {
-  virtual_organizations: {
-    LHCp: {
-      groups: {
-        user: {
-          properties: ["NormalUser"],
-        },
-        admin: {
-          properties: ["AdminUser"],
-        },
-      },
-      support: {
-        message: "Please contact the system administrator",
-        webpage: null,
-        email: null,
-      },
-      default_group: "admin",
-    },
-    PridGG: {
-      groups: {
-        admin: {
-          properties: ["NormalUser"],
-        },
-      },
-      support: {
-        message:
-          "Please restart your machine, if it still does not work, please try again later",
-        webpage: null,
-        email: null,
-      },
-      default_group: "admin",
-    },
-  },
-};
-
 export const SingleVO: Story = {
   render(props) {
     useMetadata.mockReturnValue({
       metadata: singleVOMetadata,
-      error: null,
+      error: undefined,
       isLoading: false,
     });
     return <LoginForm {...props} />;
@@ -118,7 +58,7 @@ export const MultiVO: Story = {
   render(props) {
     useMetadata.mockReturnValue({
       metadata: multiVOMetadata,
-      error: null,
+      error: undefined,
       isLoading: false,
     });
     return <LoginForm {...props} />;

--- a/packages/diracx-web-components/stories/mocks/metadata.fixtures.mock.ts
+++ b/packages/diracx-web-components/stories/mocks/metadata.fixtures.mock.ts
@@ -1,0 +1,55 @@
+export const singleVOMetadata = {
+  virtual_organizations: {
+    DTeam: {
+      groups: {
+        admin: {
+          properties: ["AdminUser"],
+        },
+        user: {
+          properties: ["NormalUser"],
+        },
+      },
+      support: {
+        message: "Please contact system administrator",
+        webpage: null,
+        email: null,
+      },
+      default_group: "user",
+    },
+  },
+};
+
+export const multiVOMetadata = {
+  virtual_organizations: {
+    LHCp: {
+      groups: {
+        user: {
+          properties: ["NormalUser"],
+        },
+        admin: {
+          properties: ["AdminUser"],
+        },
+      },
+      support: {
+        message: "Please contact the system administrator",
+        webpage: null,
+        email: null,
+      },
+      default_group: "admin",
+    },
+    PridGG: {
+      groups: {
+        admin: {
+          properties: ["NormalUser"],
+        },
+      },
+      support: {
+        message:
+          "Please restart your machine, if it still does not work, please try again later",
+        webpage: null,
+        email: null,
+      },
+      default_group: "admin",
+    },
+  },
+};

--- a/packages/diracx-web-components/stories/mocks/metadata.mock.ts
+++ b/packages/diracx-web-components/stories/mocks/metadata.mock.ts
@@ -1,7 +1,0 @@
-import { fn } from "@storybook/test";
-// Aliased '@/hooks/metadata' as '@actual/hooks/metadata' in the Storybook config to prevent the mock from importing itself.
-// @ts-expect-error: Cannot find module '@actual/hooks/metadata'
-import * as actual from "@actual/hooks/metadata";
-
-export const useMetadata = fn(actual.useMetadata);
-export type Metadata = actual.Metadata;

--- a/packages/diracx-web-components/stories/mocks/metadata.mock.tsx
+++ b/packages/diracx-web-components/stories/mocks/metadata.mock.tsx
@@ -1,0 +1,5 @@
+import { fn } from "@storybook/test";
+import * as actual from "../../src/hooks/metadata";
+
+export const useMetadata = fn(actual.useMetadata);
+export type Metadata = actual.Metadata;

--- a/packages/diracx-web-components/stories/mocks/react-oidc.mock.ts
+++ b/packages/diracx-web-components/stories/mocks/react-oidc.mock.ts
@@ -1,8 +1,0 @@
-import { fn } from "@storybook/test";
-// Aliased the '@axa-fr/react-oidc' library as '@actual/react-oidc' in the Storybook config to prevent the mock from importing itself.
-// @ts-expect-error: Cannot find module '@actual/react-oidc'
-import * as actual from "@actual/react-oidc";
-
-export const useOidc = fn(actual.useOidc);
-export const useOidcAccessToken = fn(actual.useOidcAccessToken);
-export const OidcProvider = actual.OidcProvider;

--- a/packages/diracx-web-components/stories/mocks/react-oidc.mock.tsx
+++ b/packages/diracx-web-components/stories/mocks/react-oidc.mock.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+const jestFn =
+  // Storybook runs in the browser – `jest` is not defined there
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  typeof jest !== "undefined" ? jest.fn : (fn: any) => fn;
+
+const noop = () => {};
+
+/* ---------- API surface --------------------------------- */
+export const useOidc = jestFn(() => ({ login: noop, isAuthenticated: false }));
+export const useOidcAccessToken = jestFn(() => ({
+  accessToken: "123456789",
+  accessTokenPayload: { preferred_username: "John Doe" },
+}));
+
+export const OidcProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <div data-testid="mock-oidc-provider">{children}</div>;
+/* -------------------------------------------------------- */

--- a/packages/diracx-web-components/test/ApplicationDialog.test.tsx
+++ b/packages/diracx-web-components/test/ApplicationDialog.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { composeStories } from "@storybook/react";
-import * as stories from "../stories/BaseApp.stories";
+import * as stories from "../stories/ApplicationDialog.stories";
 
-// Compose all the stories
+// Compose all stories
 const { Default } = composeStories(stories);
 
 jest.mock("jsoncrush", () => ({
@@ -10,9 +10,10 @@ jest.mock("jsoncrush", () => ({
   uncrush: jest.fn().mockImplementation((data) => data.replace("crushed-", "")),
 }));
 
-describe("BaseApp", () => {
-  it("renders the LoggedIn story", () => {
+describe("ApplicationDialog", () => {
+  it("renders the Default story with the dialog open", () => {
     render(<Default />);
-    expect(screen.getByText("Hello John Doe")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Available applications")).toBeInTheDocument();
   });
 });

--- a/packages/diracx-web-components/test/Dashboard.test.tsx
+++ b/packages/diracx-web-components/test/Dashboard.test.tsx
@@ -1,17 +1,17 @@
-import React from "react";
 import { render, fireEvent } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
 import { useOidc, useOidcAccessToken } from "@axa-fr/react-oidc";
 import { useMediaQuery } from "@mui/material";
-import Dashboard from "../src/components/DashboardLayout/Dashboard";
-import { ThemeProvider } from "../src/contexts/ThemeProvider";
+import * as stories from "../stories/Dashboard.stories";
 
-// Mock the useOidcAccessToken and useOidc hooks
+// Compose your Storybook stories (this will include all decorators/args)
+const { Default } = composeStories(stories);
+
 jest.mock("@axa-fr/react-oidc", () => ({
-  useOidcAccessToken: jest.fn(),
   useOidc: jest.fn(),
+  useOidcAccessToken: jest.fn(),
 }));
 
-// Mock the useMediaQuery hook to control the return value
 jest.mock("@mui/material", () => ({
   ...jest.requireActual("@mui/material"),
   useMediaQuery: jest.fn(),
@@ -22,13 +22,11 @@ jest.mock("jsoncrush", () => ({
   uncrush: jest.fn().mockImplementation((data) => data.replace("crushed-", "")),
 }));
 
-describe("<Dashboard>", () => {
+describe("Dashboard", () => {
   beforeEach(() => {
-    // Mock the return value for each test
+    // Typical authenticated state (adapt to your needs)
     (useOidcAccessToken as jest.Mock).mockReturnValue({
-      accessTokenPayload: {
-        test: "test",
-      },
+      accessTokenPayload: { test: "test" },
     });
     (useOidc as jest.Mock).mockReturnValue({
       isAuthenticated: false,
@@ -39,45 +37,31 @@ describe("<Dashboard>", () => {
     jest.clearAllMocks();
   });
 
-  // Normal case
-  it("renders on desktop screen", () => {
-    (useMediaQuery as jest.Mock).mockReturnValue(false); // e.g., desktop screen
+  it("renders in desktop mode", () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(false); // desktop
 
-    const { getByTestId } = render(
-      <ThemeProvider>
-        <Dashboard>
-          <h1>Test</h1>
-        </Dashboard>
-      </ThemeProvider>,
-    );
+    const { getByTestId } = render(<Default />);
 
-    // `drawer-temporary` should not even be in the DOM for desktop screen sizes
-    expect(() => getByTestId("drawer-temporary")).toThrow();
-    // Expect `drawer-permanent` to now be visible
+    // On desktop, the permanent drawer should be visible
     expect(getByTestId("drawer-permanent")).toBeVisible();
+
+    // The temporary drawer (for mobile) should not be rendered
+    expect(() => getByTestId("drawer-temporary")).toThrow();
   });
 
-  // Testing a hypothetical toggle button for the drawer
-  it("renders on mobile screen", () => {
-    (useMediaQuery as jest.Mock).mockReturnValue(true); // e.g., mobile screen
+  it("renders in mobile mode and opens drawer after toggle", () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(true); // mobile
 
-    const { getByTestId } = render(
-      <ThemeProvider>
-        <Dashboard>
-          <h1>Test</h1>
-        </Dashboard>
-      </ThemeProvider>,
-    );
+    const { getByTestId } = render(<Default />);
     const toggleButton = getByTestId("drawer-toggle-button");
 
-    // Assuming the drawer is initially closed
-    // `drawer-temporary` should not even be in the DOM initially
+    // Initially, the temporary drawer is not visible
     expect(() => getByTestId("drawer-temporary")).toThrow();
 
-    // Simulate a button click
+    // Simulate user opening the drawer
     fireEvent.click(toggleButton);
 
-    // Expect the drawer to now be visible
+    // Now, the temporary drawer should be visible
     expect(getByTestId("drawer-temporary")).toBeVisible();
   });
 });

--- a/packages/diracx-web-components/test/DashboardDrawer.test.tsx
+++ b/packages/diracx-web-components/test/DashboardDrawer.test.tsx
@@ -1,80 +1,23 @@
-import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import { Dashboard as DashboardIcon } from "@mui/icons-material";
-import DashboardDrawer from "../src/components/DashboardLayout/DashboardDrawer";
-import { ThemeProvider } from "../src/contexts/ThemeProvider";
-import { ApplicationsContext } from "../src/contexts/ApplicationsProvider";
-import { DashboardGroup } from "../src/types/DashboardGroup";
-import { applicationList } from "../src/components/ApplicationList";
+import { composeStories } from "@storybook/react";
+import * as stories from "../stories/DashboardDrawer.stories";
 
 jest.mock("jsoncrush", () => ({
   crush: jest.fn().mockImplementation((data) => `crushed-${data}`),
   uncrush: jest.fn().mockImplementation((data) => data.replace("crushed-", "")),
 }));
 
-const mockSections: DashboardGroup[] = [
-  {
-    title: "Group 1",
-    extended: true,
-    items: [
-      {
-        title: "App 1",
-        id: "app1",
-        type: "Dashboard",
-        icon: DashboardIcon,
-      },
-    ],
-  },
-];
+const { Default } = composeStories(stories);
 
-const MockApplicationProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}): JSX.Element => (
-  <ApplicationsContext.Provider
-    value={[mockSections, () => {}, applicationList]}
-  >
-    {children}
-  </ApplicationsContext.Provider>
-);
-
-describe("<DashboardDrawer>", () => {
-  it("renders correctly", () => {
-    const { getByText } = render(
-      <ThemeProvider>
-        <MockApplicationProvider>
-          <DashboardDrawer
-            variant="permanent"
-            mobileOpen={false}
-            width={100}
-            handleDrawerToggle={function (): void {
-              throw new Error("Function not implemented.");
-            }}
-          />
-        </MockApplicationProvider>
-      </ThemeProvider>,
-    );
-
-    expect(getByText("App 1")).toBeInTheDocument();
+describe("DashboardDrawer", () => {
+  it("renders the app title from the context", () => {
+    const { getByText } = render(<Default />);
+    expect(getByText("App Name")).toBeInTheDocument();
   });
 
-  it("handles context menu", () => {
-    const { getByText, getByTestId } = render(
-      <ThemeProvider>
-        <MockApplicationProvider>
-          <DashboardDrawer
-            variant="permanent"
-            mobileOpen={false}
-            width={100}
-            handleDrawerToggle={function (): void {
-              throw new Error("Function not implemented.");
-            }}
-          />
-        </MockApplicationProvider>
-      </ThemeProvider>,
-    );
-
-    fireEvent.contextMenu(getByText("App 1"));
-
+  it("shows the context menu when right-clicking on an app item", () => {
+    const { getByText, getByTestId } = render(<Default />);
+    fireEvent.contextMenu(getByText("App Name"));
     expect(getByTestId("context-menu")).toBeInTheDocument();
   });
 });

--- a/packages/diracx-web-components/test/DataTable.test.tsx
+++ b/packages/diracx-web-components/test/DataTable.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
+import * as stories from "../stories/DataTable.stories";
+
+// Compose the stories to get actual Storybook behavior (decorators, args, etc)
+const { Default } = composeStories(stories);
+
+describe("DataTable", () => {
+  it("renders table title", () => {
+    render(<Default />);
+    expect(screen.getByText("Data Table")).toBeInTheDocument();
+  });
+
+  it("renders column headers", () => {
+    render(<Default />);
+    expect(screen.getByText("ID")).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("renders Edit menu item if menu is opened", () => {
+    render(<Default />);
+    const moreButtons = screen.queryAllByRole("button");
+    const menuButton = moreButtons.find((btn) =>
+      /menu|action|more/i.test(
+        btn.textContent || btn.getAttribute("aria-label") || "",
+      ),
+    );
+    if (menuButton) {
+      fireEvent.click(menuButton);
+      expect(screen.getByText("Edit")).toBeInTheDocument();
+    }
+  });
+});

--- a/packages/diracx-web-components/test/DrawerItem.test.tsx
+++ b/packages/diracx-web-components/test/DrawerItem.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
+import * as stories from "../stories/DrawerItem.stories";
+
+jest.mock("jsoncrush", () => ({
+  crush: jest.fn().mockImplementation((data) => `crushed-${data}`),
+  uncrush: jest.fn().mockImplementation((data) => data.replace("crushed-", "")),
+}));
+
+// Compose the stories to get actual Storybook behavior (decorators, args, etc)
+const { Default } = composeStories(stories);
+
+describe("DrawerItem", () => {
+  it("renders with the default props", () => {
+    render(<Default />);
+
+    // Checks for item title
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+});

--- a/packages/diracx-web-components/test/DrawerItemGroup.test.tsx
+++ b/packages/diracx-web-components/test/DrawerItemGroup.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
+import * as stories from "../stories/DrawerItemGroup.stories";
+
+// Compose the stories to get actual Storybook behavior (decorators, args, etc)
+const { Default } = composeStories(stories);
+
+jest.mock("jsoncrush", () => ({
+  crush: jest.fn().mockImplementation((data) => `crushed-${data}`),
+  uncrush: jest.fn().mockImplementation((data) => data.replace("crushed-", "")),
+}));
+
+describe("DrawerItemGroup", () => {
+  it("renders group title", () => {
+    render(<Default />);
+    expect(screen.getByText("Group Title")).toBeInTheDocument();
+  });
+
+  it("renders dashboard item", () => {
+    render(<Default />);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+
+  it("calls setUserDashboard when an item is clicked", () => {
+    render(<Default />);
+    const dashboardItem = screen.getByText("Dashboard");
+    fireEvent.click(dashboardItem);
+    expect(dashboardItem).toBeInTheDocument();
+  });
+});

--- a/packages/diracx-web-components/test/ErrorBox.test.tsx
+++ b/packages/diracx-web-components/test/ErrorBox.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
+import * as stories from "../stories/ErrorBox.stories";
+
+// Compose the stories to get actual Storybook behavior (decorators, args, etc)
+const { Default } = composeStories(stories);
+
+describe("ErrorBox", () => {
+  it("renders default error message", () => {
+    render(<Default />);
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("renders custom error message", () => {
+    render(<Default msg="Custom error occurred" />);
+    expect(screen.getByText("Custom error occurred")).toBeInTheDocument();
+  });
+
+  it("renders reset button if reset prop is provided and calls it on click", () => {
+    const resetMock = jest.fn();
+    render(<Default reset={resetMock} />);
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(resetMock).toHaveBeenCalled();
+  });
+
+  it("does not render reset button if reset prop is not provided", () => {
+    render(<Default />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/packages/diracx-web-components/test/LoginForm.test.tsx
+++ b/packages/diracx-web-components/test/LoginForm.test.tsx
@@ -1,134 +1,74 @@
-import { render, fireEvent, screen } from "@testing-library/react";
-import React from "react";
-import { LoginForm } from "../src/components/Login/LoginForm";
-import { ThemeProvider } from "../src/contexts/ThemeProvider";
-import { useMetadata } from "../src/hooks/metadata";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
+import {
+  singleVOMetadata,
+  multiVOMetadata,
+} from "../stories/mocks/metadata.fixtures.mock";
+import * as stories from "../stories/LoginForm.stories";
+import { useOidc } from "../stories/mocks/react-oidc.mock";
 
-const singleVOMetadata = {
-  virtual_organizations: {
-    DTeam: {
-      groups: {
-        admin: {
-          properties: ["AdminUser"],
-        },
-        user: {
-          properties: ["NormalUser"],
-        },
-      },
-      support: {
-        message: "Please contact system administrator",
-        webpage: null,
-        email: null,
-      },
-      default_group: "user",
-    },
-  },
-};
+const { SingleVO, MultiVO } = composeStories(stories);
 
-const multiVOMetadata = {
-  virtual_organizations: {
-    LHCp: {
-      groups: {
-        user: {
-          properties: ["NormalUser"],
-        },
-        admin: {
-          properties: ["AdminUser"],
-        },
-      },
-      support: {
-        message: "Please contact the system administrator",
-        webpage: null,
-        email: null,
-      },
-      default_group: "admin",
-    },
-    PridGG: {
-      groups: {
-        admin: {
-          properties: ["NormalUser"],
-        },
-      },
-      support: {
-        message:
-          "Please restart your machine, if it still does not work, please try again later",
-        webpage: null,
-        email: null,
-      },
-      default_group: "admin",
-    },
-  },
-};
-
-// Mock the necessary hooks and external modules
-jest.mock("../src/hooks/metadata");
-
-jest.mock("../src/hooks/utils", () => ({
-  useDiracxUrl: () => "https://example.com",
-}));
-
-jest.mock("@axa-fr/react-oidc", () => ({
-  useOidc: () => ({
-    login: jest.fn(),
-    isAuthenticated: false,
-  }),
+jest.mock("../src/hooks/metadata", () => ({
+  useMetadata: jest.fn(() => ({
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    metadata: require("../stories/LoginForm.stories").singleVOMetadata,
+    error: null,
+    isLoading: false,
+  })),
 }));
 
 describe("LoginForm", () => {
-  // Should render a text field to select the VO
-  it("renders correctly multiple VOs", () => {
-    (useMetadata as jest.Mock).mockReturnValue({ metadata: multiVOMetadata });
-
-    render(
-      <ThemeProvider>
-        <LoginForm />
-      </ThemeProvider>,
+  beforeEach(() => {
+    // reset the metadata mock back to singleVOMetadata
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    (require("../src/hooks/metadata").useMetadata as jest.Mock).mockReturnValue(
+      {
+        metadata: singleVOMetadata,
+        error: null,
+        isLoading: false,
+      },
     );
 
-    // Check the presence of the VO select field (it should not presented as a title since there are multiple VOs)
-    // Check the presence of the login button (it should not be present as we have not selected a VO)
-    const input = screen
-      .getByTestId("autocomplete-vo-select")
-      .querySelector("input");
-    expect(() => screen.getByTestId("h3-vo-name")).toThrow();
-    expect(() => screen.getByTestId("button-login")).toThrow();
+    // ensure OIDC is always logged out by default
+    useOidc.mockReturnValue({ login: () => {}, isAuthenticated: false });
+  });
 
-    // Simulate typing into the input field (the VO selected does not exist)
-    // Check the presence of the login button (it should not be present as the VO does not exist)
-    fireEvent.change(input, { target: { value: "Does not exist" } });
-    expect(() => screen.getByTestId("button-login")).toThrow();
+  it("works for the SingleVO story", () => {
+    render(<SingleVO />);
 
-    // Simulate typing into the input field (partial VO name)
-    // Check the presence of the login button (it should be present as the VO exists)
-    fireEvent.change(input, { target: { value: "LHC" } });
-    fireEvent.click(screen.getByText("LHCp"));
-
-    // Check the presence of the group selector
+    // now immediately rendered
+    expect(screen.getByTestId("h3-vo-name")).toBeInTheDocument();
+    expect(screen.queryByTestId("autocomplete-vo-select")).toBeNull();
     expect(screen.getByTestId("select-group")).toBeInTheDocument();
-
-    // Check the presence of the login button (it should be present as the VO exists)
     expect(screen.getByTestId("button-login")).toBeInTheDocument();
   });
 
-  // Should render a title with the VO name
-  it("renders correctly single VO", () => {
-    (useMetadata as jest.Mock).mockReturnValue({ metadata: singleVOMetadata });
-
-    render(
-      <ThemeProvider>
-        <LoginForm />
-      </ThemeProvider>,
+  it("works for the MultiVO story", () => {
+    // for this test only, override to multiVOMetadata
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    (require("../src/hooks/metadata").useMetadata as jest.Mock).mockReturnValue(
+      {
+        metadata: multiVOMetadata,
+        error: null,
+        isLoading: false,
+      },
     );
 
-    // Check the presence of the VO title
-    // The select field should not be presented as a title since there is only one VO
-    expect(screen.getByTestId("h3-vo-name")).toBeInTheDocument();
-    expect(() => screen.getByTestId("autocomplete-vo-select")).toThrow();
+    render(<MultiVO />);
 
-    // Check the presence of the group selector
+    const input = screen
+      .getByTestId("autocomplete-vo-select")
+      .querySelector("input") as HTMLInputElement;
+
+    // before selection
+    expect(screen.queryByTestId("button-login")).toBeNull();
+
+    // pick “LHCp”
+    fireEvent.change(input, { target: { value: "LHC" } });
+    fireEvent.click(screen.getByText("LHCp"));
+
     expect(screen.getByTestId("select-group")).toBeInTheDocument();
-
-    // Check the presence of the login button (it should be present as the VO exists)
     expect(screen.getByTestId("button-login")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- The CI does not identify issues in the stories because they are not really covered
- Unit tests are not really useful at the moment, because most of the tests are done through cypress, but they are still useful to tests components in isolation (could cover potential cases in extensions)
- There are a lot of duplications between the stories and the tests and this can be cumbersome for the developers (we actually stopped writing unit tests)

In this PR I link stories to unit tests: developers will have to create stories for their components, and instead of testing the components, we will test the stories.
- we minimize duplication between stories and unit tests
- we actually test the stories and prevent breaking them