### PR TITLE
feat: handle outdated imported states with automatic structure update

### DIFF
--- a/docs/developer/create_application.md
+++ b/docs/developer/create_application.md
@@ -6,7 +6,15 @@ The applicatins created here will be available for DiracX-Web and for all the ex
 
 ### Declare the application
 
-In the file `packages/diracx-web-components/src/components/ApplicationList.ts` you can extend the `applicationList` with your new app. You must provide a name (explicit), the component representing the new app and an icon that will appear in the `Add application` menu. You can also give two functions, `setState` and `getState`, to configure the export and import of your app.
+In the file `packages/diracx-web-components/src/components/ApplicationList.ts` you can extend the `applicationList` with your new app. 
+
+You must provide: 
+- A clear and explicit name
+- The component representing the new app 
+- An icon that will appear in the `Add application` menu
+- An optional function, `validateAndConvertState`, which identifies and corrects the structure of a JSON pasted by the user during import. This function ensures compatibility between versions by transforming the pasted state into a valid, updated version. It should be reviewed and updated in any version that modifies the exported/imported state structure
+
+💡You can look at the type `ApplicationMetadata` for more details
 
 ### Code the application
 

--- a/docs/user/list_and_share_applications.md
+++ b/docs/user/list_and_share_applications.md
@@ -97,3 +97,5 @@ When managing multiple instances of the same application, grouping can help you 
 1. **Share**: You can export the status of an app by clicking on the share button in the top-right corner of the screen. After clicking, you can select which group and app you want to share and then copy a text corresponding to the states of the selected applications.
 
 2. **Import**: Next to the export button you can find the import button. You can paste into the window opened by the button the text corresponding to one or multiple shared apps. This will create a new group named *Imported App* with the imported applications and their settings. 
+
+**Good to know:** When switching to a new version, the settings you are trying to import may no longer be valid. In this case, a new window will appear, offering to resolve the issue by updating the state copied to your clipboard. This updated version preserves your imported rules as much as possible. 

--- a/packages/diracx-web-components/src/components/ApplicationList.ts
+++ b/packages/diracx-web-components/src/components/ApplicationList.ts
@@ -2,13 +2,16 @@
 
 import { FolderCopy, Monitor } from "@mui/icons-material";
 import ApplicationMetadata from "../types/ApplicationMetadata";
-import JobMonitor from "./JobMonitor/JobMonitor";
+import JobMonitor, {
+  validateAndConvertState as validateAndConvertState_JobMonitor,
+} from "./JobMonitor/JobMonitor";
 
 export const applicationList: ApplicationMetadata[] = [
   {
     name: "Job Monitor",
     component: JobMonitor,
     icon: Monitor,
+    validateAndConvertState: validateAndConvertState_JobMonitor,
   },
   {
     name: "File Catalog",

--- a/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
@@ -213,31 +213,40 @@ export default function DashboardDrawer({
    * @param appType - The type of the app to be created.
    */
   const handleAppCreation = (appType: string) => {
-    let group = userDashboard[userDashboard.length - 1];
-    const empty = !group;
-    if (empty) {
-      //create a new group if there is no group
-      group = {
-        title: `Group ${userDashboard.length + 1}`,
-        extended: false,
-        items: [],
-      };
+    const group =
+      userDashboard.length > 0
+        ? userDashboard[userDashboard.length - 1]
+        : {
+            // Create a new group if none exists
+            title: `Group 1`,
+            extended: false,
+            items: [],
+          };
+
+    const empty = userDashboard.length === 0;
+
+    const count = group.items.filter((item) =>
+      item.title.startsWith(appType),
+    ).length;
+
+    let title = `${appType} ${count > 0 ? `${count}` : ""}`;
+    while (group.items.some((app) => app.title === title)) {
+      const match = title.match(/(\d+)$/);
+      const num = match ? parseInt(match[1], 10) + 1 : undefined;
+      title = `${appType} ${num}`;
     }
 
-    const count = userDashboard.reduce(
-      (sum, group) =>
-        sum + group.items.filter((item) => item.type === appType).length,
-      0,
-    );
-
-    const title = count > 0 ? `${appType} ${count + 1}` : `${appType}`;
-
+    let appId = `${appType} 0`;
+    while (
+      userDashboard.some((group) => group.items.some((app) => app.id === appId))
+    ) {
+      const match = appId.match(/(\d+)$/);
+      const num = match ? parseInt(match[1], 10) + 1 : 0;
+      appId = `${appType} ${num}`;
+    }
     const newApp = {
       title,
-      id: `${title}${userDashboard.reduce(
-        (sum, group) => sum + group.items.length,
-        0,
-      )}`,
+      id: appId,
       type: appType,
     };
     group.items.push(newApp);
@@ -407,9 +416,9 @@ export default function DashboardDrawer({
           </Toolbar>
           {/* Map over user app instances and render them as list items in the drawer. */}
           <List>
-            {userDashboard.map((group) => (
+            {userDashboard.map((group, index) => (
               <ListItem
-                key={group.title}
+                key={index}
                 disablePadding
                 onContextMenu={handleContextMenu("group", group.title)}
               >

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerItem.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerItem.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
   TextField,
 } from "@mui/material";
-import { DragIndicator, SvgIconComponent, Apps } from "@mui/icons-material";
+import { DragIndicator, SvgIconComponent } from "@mui/icons-material";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
   draggable,
@@ -72,7 +72,7 @@ export default function DrawerItem({
 
   const [, , appList, appId, setCurrentAppId] = useContext(ApplicationsContext);
   const { icon } = appList.find((app) => app.name === item.type) || {
-    icon: Apps,
+    icon: EggIcon,
   };
 
   useEffect(() => {
@@ -194,7 +194,7 @@ export default function DrawerItem({
         selected={appId === item.id}
       >
         <ListItemIcon>
-          <Icon component={icon ?? EggIcon} />
+          <Icon component={icon} />
         </ListItemIcon>
         {renamingItemId === item.id ? (
           <TextField

--- a/packages/diracx-web-components/src/components/DashboardLayout/ExportButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ExportButton.tsx
@@ -119,7 +119,7 @@ export function ExportButton() {
       };
     });
 
-    setSelectedState(JSON.stringify(states, null, 2));
+    setSelectedState(JSON.stringify(states));
     setDialogOpen(true);
     handleClose();
   };

--- a/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
+++ b/packages/diracx-web-components/src/components/JobMonitor/JobMonitor.tsx
@@ -27,6 +27,7 @@ import { FilterToolbar } from "../shared/FilterToolbar";
 import { InternalFilter } from "../../types/Filter";
 import { Job, SearchBody } from "../../types";
 import { JobDataTable } from "./JobDataTable";
+
 /**
  * Build the Job Monitor application
  *
@@ -322,4 +323,50 @@ export default function JobMonitor() {
       />
     </Box>
   );
+}
+
+/**
+ * This function validates and converts the state of the application
+ * It ensure that the state is in the correct format
+ * even if the structure changed between versions
+ *
+ * @param state - The state of the application
+ * @returns The parsed state of the application and a boolean indicating if the state was converted
+ * @throws Error if the state is not valid
+ */
+export function validateAndConvertState(state: string): [string, boolean] {
+  // The previous structure did not have the filters field, so we add it if it is missing
+  let parsed;
+  let isValid = true;
+  try {
+    parsed = JSON.parse(state);
+    isValid =
+      typeof parsed === "object" &&
+      typeof parsed.columnVisibility === "object" &&
+      typeof parsed.columnPinning === "object" &&
+      typeof parsed.rowSelection === "object" &&
+      typeof parsed.pagination === "object" &&
+      "pageIndex" in parsed.pagination &&
+      "pageSize" in parsed.pagination &&
+      typeof parsed.filters === "object"; // New field
+
+    if (isValid) return [state, false];
+  } catch (e) {
+    // Convert the state to the new version
+    isValid = false;
+    if (e instanceof SyntaxError) {
+      // The state is not a valid JSON
+      throw new Error("The state is not a valid JSON");
+    }
+  }
+
+  const newState = {
+    filters: [], // Create an empty filters array
+    columnVisibility: parsed.columnVisibility,
+    columnPinning: parsed.columnPinning,
+    rowSelection: parsed.rowSelection,
+    pagination: parsed.pagination,
+  };
+
+  return [JSON.stringify(newState), true];
 }

--- a/packages/diracx-web-components/src/types/ApplicationMetadata.ts
+++ b/packages/diracx-web-components/src/types/ApplicationMetadata.ts
@@ -7,6 +7,9 @@ export default interface ApplicationMetadata {
   name: string;
   component: ElementType;
   icon: SvgIconComponent;
+  validateAndConvertState?: (
+    state: ApplicationState,
+  ) => [ApplicationState, boolean];
 }
 
 export type ApplicationState = string;

--- a/packages/diracx-web-components/src/types/ApplicationSettings.tsx
+++ b/packages/diracx-web-components/src/types/ApplicationSettings.tsx
@@ -1,0 +1,7 @@
+import type { ApplicationState } from "./ApplicationMetadata";
+
+export type ApplicationSettings = {
+  appType: string;
+  appName: string;
+  state: ApplicationState;
+};

--- a/packages/diracx-web-components/src/types/index.ts
+++ b/packages/diracx-web-components/src/types/index.ts
@@ -5,3 +5,4 @@ export * from "./DashboardItem";
 export * from "./SearchBody";
 export * from "./Job";
 export * from "./JobHistory";
+export * from "./ApplicationSettings";

--- a/packages/diracx-web/test/e2e/dashboard.cy.ts
+++ b/packages/diracx-web/test/e2e/dashboard.cy.ts
@@ -45,7 +45,7 @@ describe("DashboardDrawer", { retries: { runMode: 5, openMode: 3 } }, () => {
 
     cy.contains("Others").click();
     // Check if the application is added
-    cy.contains("Job Monitor 2").should("be.visible");
+    cy.contains("Job Monitor").should("be.visible");
   });
 
   it("should handle application deletion", () => {

--- a/packages/diracx-web/test/e2e/importExportState.cy.ts
+++ b/packages/diracx-web/test/e2e/importExportState.cy.ts
@@ -37,7 +37,7 @@ describe("Export and import app state", () => {
     // Select 2 items to share
     cy.get('[data-testid="export-menu"]').should("be.visible");
     cy.get('[data-testid="checkbox-JobMonitor0"]').click();
-    cy.get('[data-testid="checkbox-Job Monitor 21"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 0"]').click();
 
     // Share and cancel the export
     cy.contains("Export 2 selected").should("be.visible").click();
@@ -59,7 +59,7 @@ describe("Export and import app state", () => {
       .should("be.visible")
       .click();
     cy.get('[data-testid="export-menu"]').should("be.visible");
-    cy.get('[data-testid="checkbox-Job Monitor 21"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 0"]').click();
     cy.contains("Export 1 selected").should("be.visible").click();
 
     // Copy and assert the state
@@ -71,7 +71,7 @@ describe("Export and import app state", () => {
 
     cy.get("@writeTextStub").should(
       "have.been.calledOnceWithExactly",
-      '[\n  {\n    "appType": "Job Monitor",\n    "appName": "Job Monitor 2",\n    "state": "{\\"filters\\":[],\\"columnVisibility\\":{\\"JobGroup\\":false,\\"JobType\\":false,\\"Owner\\":false,\\"OwnerGroup\\":false,\\"VO\\":false,\\"StartExecTime\\":false,\\"EndExecTime\\":false,\\"UserPriority\\":false},\\"columnPinning\\":{\\"left\\":[\\"JobID\\"],\\"right\\":[]},\\"rowSelection\\":{},\\"pagination\\":{\\"pageIndex\\":0,\\"pageSize\\":25}}"\n  }\n]',
+      '[{\"appType\":\"Job Monitor\",\"appName\":\"Job Monitor \",\"state\":\"{\\"filters\\":[],\\"columnVisibility\\":{\\"JobGroup\\":false,\\"JobType\\":false,\\"Owner\\":false,\\"OwnerGroup\\":false,\\"VO\\":false,\\"StartExecTime\\":false,\\"EndExecTime\\":false,\\"UserPriority\\":false},\\"columnPinning\\":{\\"left\\":[\\"JobID\\"],\\"right\\":[]},\\"rowSelection\\":{},\\"pagination\\":{\\"pageIndex\\":0,\\"pageSize\\":25}}\"}]',
     );
   });
 
@@ -84,11 +84,11 @@ describe("Export and import app state", () => {
       .click();
     cy.get('[data-testid="export-menu"]').should("be.visible");
     cy.get('[data-testid="checkbox-JobMonitor0"]').click();
-    cy.get('[data-testid="checkbox-Job Monitor 21"]').click();
-    cy.get('[data-testid="checkbox-Job Monitor 32"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 0"]').click();
+    cy.get('[data-testid="checkbox-Job Monitor 1"]').click();
     cy.contains("Export 3 selected").should("be.visible").click();
 
-    cy.contains('"appType": "Job Monitor"');
+    cy.contains('"appType":"Job Monitor"');
   });
 
   it("should the import button be visible", () => {
@@ -120,7 +120,7 @@ describe("Export and import app state", () => {
     cy.get('[data-testid="import-menu"]').should("be.visible");
     cy.get('[data-testid="import-menu"]').should("be.visible");
     cy.get('[datatype="import-menu-field"]').type(
-      '[\n  {\n    "appType": "Job Monitor",\n    "state": "null"\n  }\n]',
+      '[\n  {\n    "appType": "Job Monitor",\n    "appName": "Empty App",\n    "state": "null"\n  }\n]',
     );
     cy.get("button").contains("Import").click();
     cy.contains("Imported Applications").should("not.exist");


### PR DESCRIPTION
The import feature was introduced previously.
This PR improves it by adding safeguards and better handling of outdated imported states.

Over time, if a user repeatedly imports the same saved state, it may become outdated due to structural changes. This PR detects such outdated states and proposes an updated version to match the current structure.

Currently, for the `Job Monitor`, it's possible to import both:
- the complete and current structure
- an older structure without the filters field, which was recently introduced.