### PR TITLE
chore(optimization): avoid multiple renderings

### DIFF
--- a/packages/diracx-web-components/src/components/shared/SearchBar/SearchBar.tsx
+++ b/packages/diracx-web-components/src/components/shared/SearchBar/SearchBar.tsx
@@ -89,7 +89,7 @@ export function SearchBar<T extends string>({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const searchTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const lastSearchedEquationsRef = useRef<string>("");
+  const lastSearchedEquationsRef = useRef<string>("[]");
   const lastClickedTokenIndexRef = useRef<string | null>(null);
   const [tokenEquations, setTokenEquations] = useState<
     SearchBarTokenEquation[]


### PR DESCRIPTION
Due to incorrect initialization, we duplicate the rendering on opening, which triggers two resource fetches (very costly).