### PR TITLE
ci: lint PR titles instead of individual commits

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Check typescript type validity
         run: npm run ts-lint
 
+      # Individual PR commits are NOT linted: PRs are squash-merged and the
+      # PR title becomes the commit message, so the title is what must follow
+      # the conventional-commit format (enforced by pr-title.yml). This
+      # push-time check remains as a backstop for the squashed commits landing
+      # on main and for direct pushes.
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
         run: npx commitlint --last --verbose
-
-      - name: Validate PR commits with commitlint
-        if: github.event_name == 'pull_request'
-        run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR title
+
+# PRs are squash-merged and the PR title becomes the commit message on main,
+# which release-please parses for versioning. Individual commits inside a PR
+# are free-form; the PR title is what must follow the conventional-commit
+# format. Runs on `edited` so fixing the title re-triggers the check.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches-ignore:
+      - release-please-**
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      # Root-only install: commitlint and its config live in the root
+      # devDependencies; the workspaces are not needed for this check.
+      - name: Install commitlint
+        run: npm ci --workspaces=false --ignore-scripts
+
+      - name: Validate PR title with commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint --verbose


### PR DESCRIPTION
Part of #494 (stack 1/5).

PRs in this repo are squash-merged, so the **PR title** — not the individual commits — becomes the conventional commit that release-please parses on `main`. This PR moves the enforcement accordingly:

- adds `pr-title.yml`: lints the PR title with the repo's existing commitlint config; re-runs automatically when the title is edited
- removes the per-commit commitlint step from `basic.yml`; the push-time check stays as a backstop for commits landing on `main`

Commits inside PRs are free-form from here on.

Recommended follow-up (repo admin settings, not doable from a PR): set `squash_merge_commit_title` to `PR_TITLE` — currently a single-commit PR would use the commit message instead of the linted title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
