### PR TITLE
refactor(dashboard): immutable state updates, drag-drop hook, and granular contexts

### DIFF
--- a/packages/diracx-web-components/src/components/DashboardLayout/ApplicationDialog.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ApplicationDialog.tsx
@@ -11,8 +11,8 @@ import {
   Icon,
   IconButton,
 } from "@mui/material";
-import { Close } from "@mui/icons-material";
-import { ApplicationsContext } from "../../contexts/ApplicationsProvider";
+import Close from "@mui/icons-material/Close";
+import { AppListContext } from "../../contexts/ApplicationsProvider";
 
 interface AppDialogProps {
   /** Determines whether the dialog is open or not. */
@@ -34,7 +34,7 @@ export default function AppDialog({
   setAppDialogOpen,
   handleCreateApp,
 }: AppDialogProps) {
-  const applicationList = use(ApplicationsContext)[2];
+  const { appList: applicationList } = use(AppListContext);
   return (
     <Dialog
       open={appDialogOpen}

--- a/packages/diracx-web-components/src/components/DashboardLayout/Dashboard.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/Dashboard.tsx
@@ -4,14 +4,11 @@ import { useState } from "react";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
-import { Menu } from "@mui/icons-material";
+import Menu from "@mui/icons-material/Menu";
 import Toolbar from "@mui/material/Toolbar";
 import Stack from "@mui/material/Stack";
 import { Typography, useMediaQuery, useTheme } from "@mui/material";
-import {
-  useApplicationTitle,
-  useApplicationType,
-} from "../../hooks/application";
+import { useCurrentApplication } from "../../hooks/application";
 import { ProfileButton } from "./ProfileButton";
 import { ThemeToggleButton } from "./ThemeToggleButton";
 import DashboardDrawer from "./DashboardDrawer";
@@ -42,8 +39,9 @@ export default function Dashboard({
   logoURL,
   documentationURL,
 }: DashboardProps) {
-  const appTitle = useApplicationTitle();
-  const appType = useApplicationType();
+  const currentApp = useCurrentApplication();
+  const appTitle = currentApp?.title ?? null;
+  const appType = currentApp?.type ?? null;
 
   /** Theme and media query */
   const theme = useTheme();
@@ -154,7 +152,8 @@ export default function Dashboard({
           flexGrow: 1,
           display: "flex",
           flexDirection: "column",
-          width: { sm: `${drawerWidth}px` },
+          width: { sm: `calc(100% - ${drawerWidth}px)` },
+          minWidth: 0,
         }}
       >
         <Toolbar />

--- a/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
@@ -75,7 +75,7 @@ export default function DashboardDrawer({
   const theme = useTheme();
 
   // Set up drag and drop
-  useDashboardDragDrop(userDashboard, setUserDashboard);
+  useDashboardDragDrop(setUserDashboard);
 
   const handleAppCreation = (appType: string) => {
     const group =

--- a/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DashboardDrawer.tsx
@@ -1,29 +1,26 @@
 "use client";
 
 import {
-  Box,
-  Button,
   Drawer,
   List,
   ListItem,
   ListItemButton,
   ListItemIcon,
   ListItemText,
-  Menu,
-  MenuItem,
-  Popover,
-  TextField,
   Toolbar,
   useTheme,
 } from "@mui/material";
-import { MenuBook, Add } from "@mui/icons-material";
-import React, { use, useEffect, useState } from "react";
-import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
-import { ApplicationsContext } from "../../contexts/ApplicationsProvider";
-import { DashboardGroup } from "../../types";
+import MenuBook from "@mui/icons-material/MenuBook";
+import Add from "@mui/icons-material/Add";
+import React, { use, useRef, useState } from "react";
+import {
+  CurrentAppContext,
+  DashboardContext,
+} from "../../contexts/ApplicationsProvider";
 import DrawerItemGroup from "./DrawerItemGroup";
 import AppDialog from "./ApplicationDialog";
+import DrawerContextMenu from "./DrawerContextMenu";
+import useDashboardDragDrop from "./useDashboardDragDrop";
 
 interface DashboardDrawerProps {
   /** The variant of the drawer. Usually temporary if on mobile and permanent otherwise. */
@@ -55,12 +52,7 @@ export default function DashboardDrawer({
   logoURL = "/DIRAC-logo.png",
   documentationURL,
 }: DashboardDrawerProps) {
-  // Determine the container for the Drawer based on whether the window object exists.
-  const container =
-    window !== undefined ? () => window.document.body : undefined;
-  // Check if the drawer is in "temporary" mode.
   const isTemporary = variant === "temporary";
-  // Whether the modal for Application Creation is open
   const [appDialogOpen, setAppDialogOpen] = useState(false);
 
   const [contextMenu, setContextMenu] = useState<{
@@ -69,155 +61,27 @@ export default function DashboardDrawer({
   } | null>(null);
 
   const [contextState, setContextState] = useState<{
-    type: string | null;
+    type: "group" | "item" | null;
     id: string | null;
   }>({ type: null, id: null });
 
-  const [popAnchorEl, setPopAnchorEl] = useState<HTMLElement | null>(null);
   const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
   const [renamingGroupId, setRenamingGroupId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
 
-  // Define the applications that are accessible to users.
-  // Each application has an associated icon and path.
-  const [userDashboard, setUserDashboard, , , setCurrentAppId] =
-    use(ApplicationsContext);
+  const { userDashboard, setUserDashboard } = use(DashboardContext);
+  const { setCurrentAppId } = use(CurrentAppContext);
 
   const theme = useTheme();
 
-  useEffect(() => {
-    // Handle changes to app instances when drag and drop occurs.
-    return monitorForElements({
-      onDrop({ source, location }) {
-        const target = location.current.dropTargets[0];
-        if (!target) {
-          return;
-        }
-        const sourceData = source.data;
-        const targetData = target.data;
+  // Set up drag and drop
+  useDashboardDragDrop(userDashboard, setUserDashboard);
 
-        if (location.current.dropTargets.length == 2) {
-          // If the target is an item
-          const groupTitle = targetData.title;
-          const closestEdgeOfTarget = extractClosestEdge(targetData);
-          const targetIndex = targetData.index as number;
-          const sourceGroup = userDashboard.find(
-            (group) => group.title == sourceData.title,
-          );
-          const targetGroup = userDashboard.find(
-            (group) => group.title == groupTitle,
-          );
-          const sourceIndex = sourceData.index as number;
-          const destinationIndex = (
-            closestEdgeOfTarget === "top" ? targetIndex : targetIndex + 1
-          ) as number;
-
-          reorderSections(
-            sourceGroup,
-            targetGroup,
-            sourceIndex,
-            destinationIndex,
-          );
-        } else {
-          // If the target is a group
-          const groupTitle = targetData.title;
-          const sourceGroup = userDashboard.find(
-            (group) => group.title == sourceData.title,
-          );
-          const targetGroup = userDashboard.find(
-            (group) => group.title == groupTitle,
-          );
-          const sourceIndex = sourceData.index as number;
-
-          reorderSections(sourceGroup, targetGroup, sourceIndex);
-        }
-      },
-    });
-
-    /**
-     * Reorders app instances within a group or between different groups.
-     *
-     * @param sourceGroup - The source group from which the app instance is being moved.
-     * @param destinationGroup - The destination group where the app instance is being moved to.
-     * @param sourceIndex - The index of the app instance within the source group.
-     * @param destinationIndex - The index where the app instance should be placed in the destination group.
-     *                           If null, the app instance will be placed at the end of the destination group.
-     */
-    function reorderSections(
-      sourceGroup: DashboardGroup | undefined,
-      destinationGroup: DashboardGroup | undefined,
-      sourceIndex: number,
-      destinationIndex: number | null = null,
-    ) {
-      if (sourceGroup && destinationGroup) {
-        if (
-          sourceGroup.title === destinationGroup.title &&
-          destinationIndex &&
-          sourceIndex < destinationIndex
-        ) {
-          destinationIndex -= 1; // Corrects the index within the same group if needed
-        }
-        if (
-          sourceGroup.title === destinationGroup.title &&
-          (destinationIndex == null || sourceIndex === destinationIndex)
-        ) {
-          return; // Nothing to do
-        }
-
-        if (sourceGroup.title === destinationGroup.title) {
-          const sourceItems = [...sourceGroup.items];
-
-          const [removed] = sourceItems.splice(sourceIndex, 1);
-
-          if (destinationIndex === null) {
-            destinationIndex = sourceItems.length;
-          }
-          sourceItems.splice(destinationIndex, 0, removed);
-
-          setUserDashboard((groups) =>
-            groups.map((group) =>
-              group.title === sourceGroup.title
-                ? { ...group, items: sourceItems }
-                : group,
-            ),
-          );
-        } else {
-          const sourceItems = [...sourceGroup.items];
-
-          const [removed] = sourceItems.splice(sourceIndex, 1);
-
-          const destinationItems = [...destinationGroup.items];
-
-          if (destinationIndex === null) {
-            destinationIndex = destinationItems.length;
-          }
-          destinationItems.splice(destinationIndex, 0, removed);
-
-          setUserDashboard((groups) =>
-            groups.map((group) =>
-              group.title === sourceGroup.title
-                ? { ...group, items: sourceItems }
-                : group.title === destinationGroup.title
-                  ? { ...group, items: destinationItems }
-                  : group,
-            ),
-          );
-        }
-      }
-    }
-  }, [setUserDashboard, userDashboard]);
-
-  /**
-   * Handles the creation of a new app in the dashboard drawer.
-   *
-   * @param appType - The type of the app to be created.
-   */
   const handleAppCreation = (appType: string) => {
     const group =
       userDashboard.length > 0
         ? userDashboard[userDashboard.length - 1]
         : {
-            // Create a new group if none exists
             title: `Group 1`,
             extended: false,
             items: [],
@@ -249,18 +113,19 @@ export default function DashboardDrawer({
       id: appId,
       type: appType,
     };
-    group.items.push(newApp);
+    // Build a new group object instead of mutating the one held in state
+    const updatedGroup = { ...group, items: [...group.items, newApp] };
     if (empty) {
-      setUserDashboard((userDashboard) => [...userDashboard, group]);
+      setUserDashboard((userDashboard) => [...userDashboard, updatedGroup]);
     } else {
       setUserDashboard((userDashboard) =>
-        userDashboard.map((g) => (g.title === group.title ? group : g)),
+        userDashboard.map((g) => (g.title === group.title ? updatedGroup : g)),
       );
     }
     setCurrentAppId(newApp.id);
   };
 
-  let isContextStateStable = true;
+  const isContextStateStable = useRef(true);
 
   const handleContextMenu =
     (type: "group" | "item" | null = null, id: string | null = null) =>
@@ -274,16 +139,16 @@ export default function DashboardDrawer({
         mouseX: event.clientX + 2,
         mouseY: event.clientY - 6,
       });
-      if (isContextStateStable) {
+      if (isContextStateStable.current) {
         setContextState({ type, id });
-        isContextStateStable = false;
+        isContextStateStable.current = false;
       }
     };
 
   const handleCloseContextMenu = () => {
     setContextMenu(null);
     setContextState({ type: null, id: null });
-    isContextStateStable = true;
+    isContextStateStable.current = true;
   };
 
   const handleNewGroup = () => {
@@ -332,58 +197,22 @@ export default function DashboardDrawer({
   const handleRenameClick = () => {
     if (contextState.type === "group") {
       setRenamingGroupId(contextState.id);
+      setRenameValue(contextState.id ?? "");
     } else if (contextState.type === "item") {
       setRenamingItemId(contextState.id);
+      const currentTitle = userDashboard
+        .flatMap((group) => group.items)
+        .find((item) => item.id === contextState.id)?.title;
+      setRenameValue(currentTitle ?? "");
     }
-    setRenameValue("");
     handleCloseContextMenu();
   };
 
-  const popClose = () => {
-    setRenameValue("");
-    setPopAnchorEl(null);
-  };
-
-  const handleRename = () => {
-    if (contextState.type === "group") {
-      //check if the name is already taken
-      if (userDashboard.some((group) => group.title === renameValue)) {
-        return;
-      }
-      //rename the group
-      setUserDashboard((userDashboard) =>
-        userDashboard.map((group) => {
-          if (group.title === contextState.id) {
-            return { ...group, title: renameValue };
-          }
-          return group;
-        }),
-      );
-    } else if (contextState.type === "item") {
-      setUserDashboard((userDashboard) =>
-        userDashboard.map((group) => {
-          const newItems = group.items.map((item) => {
-            if (item.id === contextState.id) {
-              return { ...item, title: renameValue };
-            }
-            return item;
-          });
-          return { ...group, items: newItems };
-        }),
-      );
-    }
-
-    popClose();
-    handleCloseContextMenu();
-  };
-
-  // Use provided documentationURL or fallback to default
   const docURL = documentationURL || "https://diracx.io";
 
   return (
     <>
       <Drawer
-        container={isTemporary ? container : undefined}
         variant={variant}
         open={isTemporary ? mobileOpen : true}
         onClose={handleDrawerToggle}
@@ -403,7 +232,6 @@ export default function DashboardDrawer({
         <div
           style={{ display: "flex", flexDirection: "column", height: "100%" }}
         >
-          {/* Display the logo in the toolbar section of the drawer. */}
           <Toolbar
             sx={{
               position: "sticky",
@@ -425,11 +253,12 @@ export default function DashboardDrawer({
               }}
             />
           </Toolbar>
-          {/* Map over user app instances and render them as list items in the drawer. */}
           <List>
-            {userDashboard.map((group, index) => (
+            {userDashboard.map((group) => (
               <ListItem
-                key={index}
+                // Group titles are kept unique by the creation/rename dedup
+                // logic, so they are a stable identity across drag-reorders
+                key={group.title}
                 disablePadding
                 onContextMenu={handleContextMenu("group", group.title)}
               >
@@ -448,7 +277,6 @@ export default function DashboardDrawer({
             ))}
           </List>
 
-          {/* Render a link to documentation and a button to add applications, positioned at the bottom of the drawer. */}
           <List
             sx={{
               mt: "auto",
@@ -475,59 +303,14 @@ export default function DashboardDrawer({
             </ListItem>
           </List>
         </div>
-        <Menu
-          open={contextMenu !== null}
+        <DrawerContextMenu
+          contextMenu={contextMenu}
+          contextType={contextState.type}
           onClose={handleCloseContextMenu}
-          anchorReference="anchorPosition"
-          anchorPosition={
-            contextMenu !== null
-              ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
-              : undefined
-          }
-          data-testid="context-menu"
-        >
-          {contextState.type && (
-            <MenuItem onClick={handleRenameClick}>Rename</MenuItem>
-          )}
-          {contextState.type && (
-            <MenuItem onClick={handleDelete}>Delete</MenuItem>
-          )}
-          {contextState.type === null && (
-            <MenuItem onClick={handleNewGroup}>New Group</MenuItem>
-          )}
-        </Menu>
-        <Popover
-          open={Boolean(popAnchorEl)}
-          anchorEl={popAnchorEl}
-          onClose={popClose}
-          anchorOrigin={{
-            vertical: "center",
-            horizontal: "right",
-          }}
-          transformOrigin={{
-            vertical: "center",
-            horizontal: "left",
-          }}
-        >
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              handleRename();
-            }}
-          >
-            <Box sx={{ p: 2, display: "flex" }}>
-              <TextField
-                autoFocus
-                label="New Name"
-                value={renameValue}
-                onChange={(e) => setRenameValue(e.target.value)}
-              />
-              <Button variant="outlined" type="submit">
-                Rename
-              </Button>
-            </Box>
-          </form>
-        </Popover>
+          onRename={handleRenameClick}
+          onDelete={handleDelete}
+          onNewGroup={handleNewGroup}
+        />
       </Drawer>
       <AppDialog
         appDialogOpen={appDialogOpen}

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerContextMenu.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerContextMenu.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Menu, MenuItem } from "@mui/material";
+
+interface ContextMenuState {
+  mouseX: number;
+  mouseY: number;
+}
+
+interface DrawerContextMenuProps {
+  contextMenu: ContextMenuState | null;
+  contextType: "group" | "item" | null;
+  onClose: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+  onNewGroup: () => void;
+}
+
+export default function DrawerContextMenu({
+  contextMenu,
+  contextType,
+  onClose,
+  onRename,
+  onDelete,
+  onNewGroup,
+}: DrawerContextMenuProps) {
+  return (
+    <Menu
+      open={contextMenu !== null}
+      onClose={onClose}
+      anchorReference="anchorPosition"
+      anchorPosition={
+        contextMenu !== null
+          ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+          : undefined
+      }
+      data-testid="context-menu"
+    >
+      {contextType && <MenuItem onClick={onRename}>Rename</MenuItem>}
+      {contextType && <MenuItem onClick={onDelete}>Delete</MenuItem>}
+      {contextType === null && (
+        <MenuItem onClick={onNewGroup}>New Group</MenuItem>
+      )}
+    </Menu>
+  );
+}

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerItem.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerItem.tsx
@@ -10,7 +10,8 @@ import {
   useTheme,
   TextField,
 } from "@mui/material";
-import { DragIndicator, SvgIconComponent } from "@mui/icons-material";
+import DragIndicator from "@mui/icons-material/DragIndicator";
+import type { SvgIconComponent } from "@mui/icons-material";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
   draggable,
@@ -25,7 +26,10 @@ import {
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import EggIcon from "@mui/icons-material/Egg";
 import { ThemeProvider } from "../../contexts/ThemeProvider";
-import { ApplicationsContext } from "../../contexts/ApplicationsProvider";
+import {
+  AppListContext,
+  CurrentAppContext,
+} from "../../contexts/ApplicationsProvider";
 import { DashboardGroup, DashboardItem } from "../../types";
 
 interface DrawerItemProps {
@@ -70,7 +74,8 @@ export default function DrawerItem({
   // Represents the closest edge to the mouse cursor
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
 
-  const [, , appList, appId, setCurrentAppId] = use(ApplicationsContext);
+  const { appList } = use(AppListContext);
+  const { currentAppId: appId, setCurrentAppId } = use(CurrentAppContext);
   const { icon } = appList.find((app) => app.name === item.type) || {
     icon: EggIcon,
   };
@@ -138,9 +143,9 @@ export default function DrawerItem({
           const sourceIndex = source.data.index;
           if (typeof sourceIndex === "number") {
             const isItemBeforeSource =
-              index === sourceIndex - 1 && source.data.title === item.title;
+              index === sourceIndex - 1 && source.data.title === groupTitle;
             const isItemAfterSource =
-              index === sourceIndex + 1 && source.data.title === item.title;
+              index === sourceIndex + 1 && source.data.title === groupTitle;
 
             const isDropIndicatorHidden =
               (isItemBeforeSource && closestEdge === "bottom") ||
@@ -165,20 +170,32 @@ export default function DrawerItem({
 
   // Handle renaming of the item
   const handleItemRename = () => {
-    if (renameValue.trim() === "") return;
-    setUserDashboard((groups) =>
-      groups.map((group) => {
-        if (group.title === groupTitle) {
+    if (renameValue.trim() === "" || renameValue === item.title) return;
+    setUserDashboard((groups) => {
+      const group = groups.find((g) => g.title === groupTitle);
+      // Keep item titles unique within the group: append a counter until no
+      // *other* item has the exact same title (mirrors the group rename dedup).
+      const isTaken = (candidate: string) =>
+        group?.items.some((i) => i.id !== item.id && i.title === candidate) ??
+        false;
+      let newTitle = renameValue;
+      let counter = 1;
+      while (isTaken(newTitle)) {
+        newTitle = `${renameValue} (${counter})`;
+        counter += 1;
+      }
+      return groups.map((g) => {
+        if (g.title === groupTitle) {
           return {
-            ...group,
-            items: group.items.map((i) =>
-              i.id === item.id ? { ...item, title: renameValue } : i,
+            ...g,
+            items: g.items.map((i) =>
+              i.id === item.id ? { ...i, title: newTitle } : i,
             ),
           };
         }
-        return group;
-      }),
-    );
+        return g;
+      });
+    });
     setRenamingItemId(null);
     setRenameValue("");
   };
@@ -187,7 +204,6 @@ export default function DrawerItem({
     <>
       <ListItemButton
         disableGutters
-        key={item.title}
         onClick={() => setCurrentAppId(item.id)}
         sx={{ pl: 2, borderRadius: 2, pr: 1 }}
         ref={dragRef}
@@ -208,6 +224,9 @@ export default function DrawerItem({
                 setRenamingItemId(null);
               }
             }}
+            // The rename field only appears in direct response to a user
+            // action (context-menu "Rename"), so moving focus into it is
+            // the expected behavior, not a focus steal.
             autoFocus
             size="small"
           />

--- a/packages/diracx-web-components/src/components/DashboardLayout/DrawerItemGroup.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/DrawerItemGroup.tsx
@@ -6,8 +6,8 @@ import {
   AccordionSummary,
   TextField,
 } from "@mui/material";
-import { ExpandMore } from "@mui/icons-material";
-import React, { useEffect, useRef, useState } from "react";
+import ExpandMore from "@mui/icons-material/ExpandMore";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { DashboardGroup } from "../../types/DashboardGroup";
 import DrawerItem from "./DrawerItem";
@@ -59,16 +59,26 @@ export default function DrawerItemGroup({
   // State to track whether the user is hovering over the item during a drag operation
   const [hovered, setHovered] = useState(false);
 
-  // Handles expansion of the accordion group
-  const handleChange =
-    (title: string) => (_: React.ChangeEvent<unknown>, isExpanded: boolean) => {
-      // Set the extended state of the accordion group.
+  // Sets the extended state of an accordion group; shared by the accordion
+  // onChange handler and the drag-and-drop drop handler.
+  // setUserDashboard is a state setter, so this callback identity is stable.
+  const setGroupExpanded = useCallback(
+    (groupTitle: string, isExpanded: boolean) => {
       setUserDashboard((groups) =>
         groups.map((group) =>
-          group.title === title ? { ...group, extended: isExpanded } : group,
+          group.title === groupTitle
+            ? { ...group, extended: isExpanded }
+            : group,
         ),
       );
-    };
+    },
+    [setUserDashboard],
+  );
+
+  // Handles expansion of the accordion group
+  const handleChange =
+    (title: string) => (_: React.ChangeEvent<unknown>, isExpanded: boolean) =>
+      setGroupExpanded(title, isExpanded);
 
   useEffect(() => {
     if (!dropRef.current) return;
@@ -81,22 +91,28 @@ export default function DrawerItemGroup({
       onDragStart: () => setHovered(true),
       onDrop: () => {
         setHovered(false);
-        handleChange(title)({} as React.ChangeEvent<unknown>, true);
+        setGroupExpanded(title, true);
       },
       onDragEnter: () => setHovered(true),
       onDragLeave: () => setHovered(false),
     });
-  });
+  }, [title, setGroupExpanded]);
 
   // Handle renaming of the group
   const handleGroupRename = () => {
-    if (renameValue.trim() === "") return;
+    if (renameValue.trim() === "" || renameValue === title) return;
     setUserDashboard((groups) => {
-      const count = groups.reduce(
-        (sum, group) => (group.title.startsWith(renameValue) ? sum + 1 : sum),
-        0,
-      );
-      const newTitle = count > 0 ? `${renameValue} (${count})` : renameValue;
+      // `group.title` is used as the identity/React key, so the new title must
+      // be unique. Keep appending a counter until no *other* group has the
+      // exact same title (exact match, excluding the group being renamed).
+      const isTaken = (candidate: string) =>
+        groups.some((g) => g.title !== title && g.title === candidate);
+      let newTitle = renameValue;
+      let counter = 1;
+      while (isTaken(newTitle)) {
+        newTitle = `${renameValue} (${counter})`;
+        counter += 1;
+      }
       return groups.map((group) =>
         group.title === title ? { ...group, title: newTitle } : group,
       );
@@ -130,6 +146,9 @@ export default function DrawerItemGroup({
                 setRenamingGroupId(null);
               }
             }}
+            // The rename field only appears in direct response to a user
+            // action (context-menu "Rename"), so moving focus into it is
+            // the expected behavior, not a focus steal.
             autoFocus
             size="small"
           />

--- a/packages/diracx-web-components/src/components/DashboardLayout/ExportButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ExportButton.tsx
@@ -24,7 +24,7 @@ import SaveIcon from "@mui/icons-material/Save";
 
 import { DashboardGroup } from "../../types/DashboardGroup";
 
-import { ApplicationsContext } from "../../contexts";
+import { DashboardContext } from "../../contexts";
 
 interface ExportDialogProps {
   open: boolean;
@@ -96,7 +96,7 @@ export function ExportButton() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedApps, setSelectedApps] = useState<string[]>([]);
   const [selectedState, setSelectedState] = useState("");
-  const [groups, ,] = use(ApplicationsContext);
+  const { userDashboard: groups } = use(DashboardContext);
 
   // Function to handle the click event on the share button
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/packages/diracx-web-components/src/components/DashboardLayout/ImportButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ImportButton.tsx
@@ -12,10 +12,10 @@ import {
 } from "@mui/material";
 import InputIcon from "@mui/icons-material/Input";
 import React, { useState, use } from "react";
-import { ApplicationsContext } from "../../contexts";
+import { AppListContext, DashboardContext } from "../../contexts";
 import {
-  ApplicationMetadata,
   DashboardGroup,
+  DashboardItem,
   ApplicationSettings,
 } from "../../types";
 import { ApplicationState } from "../../types/ApplicationMetadata";
@@ -186,7 +186,8 @@ export function ImportButton() {
   const [correctStates, setCorrectStates] = useState<
     { oldSettings: ApplicationSettings; newState: ApplicationState }[]
   >([]);
-  const [userDashboard, setUserDashboard, appList] = use(ApplicationsContext);
+  const { appList } = use(AppListContext);
+  const { userDashboard, setUserDashboard } = use(DashboardContext);
 
   const handleImport = (
     importedStates: ApplicationSettings | ApplicationSettings[],
@@ -204,39 +205,50 @@ export function ImportButton() {
       title = `Imported Applications ${parseInt(title.split(" ")[2]) + 1}`;
     }
 
-    const newGroup = {
-      title: title,
-      extended: true,
-      items: [],
-    };
-
-    // Create a group only if there are valid states to import
-    if (states.some((state) => state.state !== "null"))
-      userDashboard.push(newGroup);
+    // Build the new group and any outdated-state notices locally, then
+    // commit them with immutable state updates.
+    const newItems: DashboardItem[] = [];
+    const newCorrectStates: {
+      oldSettings: ApplicationSettings;
+      newState: ApplicationState;
+    }[] = [];
 
     states.forEach((state) => {
-      if (state.state !== "null") {
-        const applicationMetadata = appList.find(
-          (app) => app.name === state.appType,
-        );
-        const appId = handleAppCreation(
-          state.appType,
-          state.appName,
-          applicationMetadata,
-          userDashboard,
-          setUserDashboard,
-        );
-        const [appState, haveChangedState] =
-          applicationMetadata?.validateAndConvertState
-            ? applicationMetadata.validateAndConvertState(state.state)
-            : [state.state, false];
-        if (haveChangedState)
-          correctStates.push({ oldSettings: state, newState: appState });
-        sessionStorage.setItem(`${appId}_State`, appState);
-      } else {
+      if (state.state === "null") {
         console.warn(`No state to import for app type: ${state.appType}`);
+        return;
       }
+      const applicationMetadata = appList.find(
+        (app) => app.name === state.appType,
+      );
+      const newApp = createApp(
+        state.appType,
+        state.appName,
+        newItems,
+        userDashboard,
+      );
+      newItems.push(newApp);
+      const [appState, haveChangedState] =
+        applicationMetadata?.validateAndConvertState
+          ? applicationMetadata.validateAndConvertState(state.state)
+          : [state.state, false];
+      if (haveChangedState)
+        newCorrectStates.push({ oldSettings: state, newState: appState });
+      sessionStorage.setItem(`${newApp.id}_State`, appState);
     });
+
+    // Create a group only if there are valid states to import
+    if (newItems.length > 0) {
+      const newGroup: DashboardGroup = {
+        title: title,
+        extended: true,
+        items: newItems,
+      };
+      setUserDashboard((prev) => [...prev, newGroup]);
+    }
+    if (newCorrectStates.length > 0) {
+      setCorrectStates((prev) => [...prev, ...newCorrectStates]);
+    }
   };
 
   return (
@@ -267,25 +279,23 @@ export function ImportButton() {
 }
 
 /**
- * Handles the creation of a new app in the dashboard drawer.
+ * Builds a new dashboard app entry without mutating any existing state.
  *
  * @param appType - The type of the app to be created.
  * @param appTitle - The title of the app to be created.
- * @param appList - The list of applications with their metadata.
- * @param userDashboard - The current state of the user's dashboard.
- * @param setUserDashboard - The function to update the user's dashboard state.
- * @returns The ID of the newly created app.
+ * @param groupItems - The items already added to the group being built
+ * (used for title deduplication and ID uniqueness).
+ * @param userDashboard - The current state of the user's dashboard (read-only,
+ * used for ID uniqueness).
+ * @returns The newly created app entry.
  */
-function handleAppCreation(
+function createApp(
   appType: string,
   appTitle: string,
-  applicationMetadata: ApplicationMetadata | undefined,
+  groupItems: DashboardItem[],
   userDashboard: DashboardGroup[],
-  setUserDashboard: React.Dispatch<React.SetStateAction<DashboardGroup[]>>,
-): string {
-  const group = userDashboard[userDashboard.length - 1];
-
-  const count = group.items.filter((item) =>
+): DashboardItem {
+  const count = groupItems.filter((item) =>
     item.title.startsWith(appTitle),
   ).length;
 
@@ -293,22 +303,19 @@ function handleAppCreation(
 
   let appId = `${appType} 0`;
   while (
-    userDashboard.some((group) => group.items.some((app) => app.id === appId))
+    userDashboard.some((group) =>
+      group.items.some((app) => app.id === appId),
+    ) ||
+    groupItems.some((app) => app.id === appId)
   ) {
     const match = appId.match(/(\d+)$/);
     const num = match ? parseInt(match[1], 10) + 1 : 0;
     appId = `${appType} ${num}`;
   }
 
-  const newApp = {
+  return {
     title: title,
     id: appId,
     type: appType,
   };
-  group.items.push(newApp);
-  setUserDashboard((userDashboard) =>
-    userDashboard.map((g) => (g.title === group.title ? group : g)),
-  );
-
-  return appId;
 }

--- a/packages/diracx-web-components/src/components/DashboardLayout/ProfileButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ProfileButton.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useOidc, useOidcAccessToken } from "@axa-fr/react-oidc";
-import {
-  Info,
-  Logout,
-  CorporateFare,
-  Groups,
-  Person,
-  ExpandMore,
-} from "@mui/icons-material";
+import Info from "@mui/icons-material/Info";
+import Logout from "@mui/icons-material/Logout";
+import CorporateFare from "@mui/icons-material/CorporateFare";
+import Groups from "@mui/icons-material/Groups";
+import Person from "@mui/icons-material/Person";
+import ExpandMore from "@mui/icons-material/ExpandMore";
 import {
   Accordion,
   AccordionDetails,

--- a/packages/diracx-web-components/src/components/DashboardLayout/ThemeToggleButton.tsx
+++ b/packages/diracx-web-components/src/components/DashboardLayout/ThemeToggleButton.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { IconButton } from "@mui/material";
-import { DarkMode, LightMode } from "@mui/icons-material";
+import DarkMode from "@mui/icons-material/DarkMode";
+import LightMode from "@mui/icons-material/LightMode";
 import { useTheme } from "../../hooks/theme";
 
 /**

--- a/packages/diracx-web-components/src/components/DashboardLayout/useDashboardDragDrop.ts
+++ b/packages/diracx-web-components/src/components/DashboardLayout/useDashboardDragDrop.ts
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { DashboardGroup } from "../../types";
+
+/**
+ * Custom hook that sets up drag-and-drop monitoring for dashboard items.
+ * Handles reordering items within and between groups.
+ */
+export default function useDashboardDragDrop(
+  userDashboard: DashboardGroup[],
+  setUserDashboard: React.Dispatch<React.SetStateAction<DashboardGroup[]>>,
+) {
+  // Keep a ref to the latest dashboard so the monitor effect does not need
+  // to re-subscribe every time the dashboard changes.
+  const userDashboardRef = useRef(userDashboard);
+  useEffect(() => {
+    userDashboardRef.current = userDashboard;
+  }, [userDashboard]);
+
+  useEffect(() => {
+    return monitorForElements({
+      onDrop({ source, location }) {
+        const target = location.current.dropTargets[0];
+        if (!target) {
+          return;
+        }
+        const sourceData = source.data;
+        const targetData = target.data;
+        const currentDashboard = userDashboardRef.current;
+
+        if (location.current.dropTargets.length === 2) {
+          const groupTitle = targetData.title;
+          const closestEdgeOfTarget = extractClosestEdge(targetData);
+          const targetIndex = targetData.index as number;
+          const sourceGroup = currentDashboard.find(
+            (group) => group.title === sourceData.title,
+          );
+          const targetGroup = currentDashboard.find(
+            (group) => group.title === groupTitle,
+          );
+          const sourceIndex = sourceData.index as number;
+          const destinationIndex = (
+            closestEdgeOfTarget === "top" ? targetIndex : targetIndex + 1
+          ) as number;
+
+          reorderSections(
+            sourceGroup,
+            targetGroup,
+            sourceIndex,
+            destinationIndex,
+          );
+        } else {
+          const groupTitle = targetData.title;
+          const sourceGroup = currentDashboard.find(
+            (group) => group.title === sourceData.title,
+          );
+          const targetGroup = currentDashboard.find(
+            (group) => group.title === groupTitle,
+          );
+          const sourceIndex = sourceData.index as number;
+
+          reorderSections(sourceGroup, targetGroup, sourceIndex);
+        }
+      },
+    });
+
+    function reorderSections(
+      sourceGroup: DashboardGroup | undefined,
+      destinationGroup: DashboardGroup | undefined,
+      sourceIndex: number,
+      destinationIndex: number | null = null,
+    ) {
+      if (sourceGroup && destinationGroup) {
+        if (
+          sourceGroup.title === destinationGroup.title &&
+          destinationIndex &&
+          sourceIndex < destinationIndex
+        ) {
+          destinationIndex -= 1;
+        }
+        if (
+          sourceGroup.title === destinationGroup.title &&
+          (destinationIndex === null || sourceIndex === destinationIndex)
+        ) {
+          return;
+        }
+
+        if (sourceGroup.title === destinationGroup.title) {
+          const sourceItems = [...sourceGroup.items];
+          const [removed] = sourceItems.splice(sourceIndex, 1);
+          if (destinationIndex === null) {
+            destinationIndex = sourceItems.length;
+          }
+          sourceItems.splice(destinationIndex, 0, removed);
+
+          setUserDashboard((groups) =>
+            groups.map((group) =>
+              group.title === sourceGroup.title
+                ? { ...group, items: sourceItems }
+                : group,
+            ),
+          );
+        } else {
+          const sourceItems = [...sourceGroup.items];
+          const [removed] = sourceItems.splice(sourceIndex, 1);
+          const destinationItems = [...destinationGroup.items];
+          if (destinationIndex === null) {
+            destinationIndex = destinationItems.length;
+          }
+          destinationItems.splice(destinationIndex, 0, removed);
+
+          setUserDashboard((groups) =>
+            groups.map((group) =>
+              group.title === sourceGroup.title
+                ? { ...group, items: sourceItems }
+                : group.title === destinationGroup.title
+                  ? { ...group, items: destinationItems }
+                  : group,
+            ),
+          );
+        }
+      }
+    }
+  }, [setUserDashboard]);
+}

--- a/packages/diracx-web-components/src/components/DashboardLayout/useDashboardDragDrop.ts
+++ b/packages/diracx-web-components/src/components/DashboardLayout/useDashboardDragDrop.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 import { DashboardGroup } from "../../types";
@@ -10,16 +10,8 @@ import { DashboardGroup } from "../../types";
  * Handles reordering items within and between groups.
  */
 export default function useDashboardDragDrop(
-  userDashboard: DashboardGroup[],
   setUserDashboard: React.Dispatch<React.SetStateAction<DashboardGroup[]>>,
 ) {
-  // Keep a ref to the latest dashboard so the monitor effect does not need
-  // to re-subscribe every time the dashboard changes.
-  const userDashboardRef = useRef(userDashboard);
-  useEffect(() => {
-    userDashboardRef.current = userDashboard;
-  }, [userDashboard]);
-
   useEffect(() => {
     return monitorForElements({
       onDrop({ source, location }) {
@@ -29,100 +21,85 @@ export default function useDashboardDragDrop(
         }
         const sourceData = source.data;
         const targetData = target.data;
-        const currentDashboard = userDashboardRef.current;
+        const sourceTitle = sourceData.title as string;
+        const destinationTitle = targetData.title as string;
+        const sourceIndex = sourceData.index as number;
 
         if (location.current.dropTargets.length === 2) {
-          const groupTitle = targetData.title;
           const closestEdgeOfTarget = extractClosestEdge(targetData);
           const targetIndex = targetData.index as number;
-          const sourceGroup = currentDashboard.find(
-            (group) => group.title === sourceData.title,
-          );
-          const targetGroup = currentDashboard.find(
-            (group) => group.title === groupTitle,
-          );
-          const sourceIndex = sourceData.index as number;
           const destinationIndex = (
             closestEdgeOfTarget === "top" ? targetIndex : targetIndex + 1
           ) as number;
 
           reorderSections(
-            sourceGroup,
-            targetGroup,
+            sourceTitle,
+            destinationTitle,
             sourceIndex,
             destinationIndex,
           );
         } else {
-          const groupTitle = targetData.title;
-          const sourceGroup = currentDashboard.find(
-            (group) => group.title === sourceData.title,
-          );
-          const targetGroup = currentDashboard.find(
-            (group) => group.title === groupTitle,
-          );
-          const sourceIndex = sourceData.index as number;
-
-          reorderSections(sourceGroup, targetGroup, sourceIndex);
+          reorderSections(sourceTitle, destinationTitle, sourceIndex);
         }
       },
     });
 
+    // The groups are looked up inside the functional updater, so it always
+    // sees the freshest state — no ref mirror, no re-subscription on every
+    // dashboard change, and no window where a drop reads a stale dashboard.
     function reorderSections(
-      sourceGroup: DashboardGroup | undefined,
-      destinationGroup: DashboardGroup | undefined,
+      sourceTitle: string,
+      destinationTitle: string,
       sourceIndex: number,
       destinationIndex: number | null = null,
     ) {
-      if (sourceGroup && destinationGroup) {
-        if (
-          sourceGroup.title === destinationGroup.title &&
-          destinationIndex &&
-          sourceIndex < destinationIndex
-        ) {
-          destinationIndex -= 1;
+      setUserDashboard((groups) => {
+        const sourceGroup = groups.find((group) => group.title === sourceTitle);
+        const destinationGroup = groups.find(
+          (group) => group.title === destinationTitle,
+        );
+        if (!sourceGroup || !destinationGroup) return groups;
+
+        const sameGroup = sourceGroup.title === destinationGroup.title;
+        // Copy into a local so the updater stays pure (React StrictMode may
+        // invoke it twice in development).
+        let destIndex = destinationIndex;
+        if (sameGroup && destIndex && sourceIndex < destIndex) {
+          destIndex -= 1;
         }
-        if (
-          sourceGroup.title === destinationGroup.title &&
-          (destinationIndex === null || sourceIndex === destinationIndex)
-        ) {
-          return;
+        if (sameGroup && (destIndex === null || sourceIndex === destIndex)) {
+          return groups; // Nothing to do
         }
 
-        if (sourceGroup.title === destinationGroup.title) {
+        if (sameGroup) {
           const sourceItems = [...sourceGroup.items];
           const [removed] = sourceItems.splice(sourceIndex, 1);
-          if (destinationIndex === null) {
-            destinationIndex = sourceItems.length;
+          if (destIndex === null) {
+            destIndex = sourceItems.length;
           }
-          sourceItems.splice(destinationIndex, 0, removed);
-
-          setUserDashboard((groups) =>
-            groups.map((group) =>
-              group.title === sourceGroup.title
-                ? { ...group, items: sourceItems }
-                : group,
-            ),
-          );
-        } else {
-          const sourceItems = [...sourceGroup.items];
-          const [removed] = sourceItems.splice(sourceIndex, 1);
-          const destinationItems = [...destinationGroup.items];
-          if (destinationIndex === null) {
-            destinationIndex = destinationItems.length;
-          }
-          destinationItems.splice(destinationIndex, 0, removed);
-
-          setUserDashboard((groups) =>
-            groups.map((group) =>
-              group.title === sourceGroup.title
-                ? { ...group, items: sourceItems }
-                : group.title === destinationGroup.title
-                  ? { ...group, items: destinationItems }
-                  : group,
-            ),
+          sourceItems.splice(destIndex, 0, removed);
+          return groups.map((group) =>
+            group.title === sourceGroup.title
+              ? { ...group, items: sourceItems }
+              : group,
           );
         }
-      }
+
+        const sourceItems = [...sourceGroup.items];
+        const [removed] = sourceItems.splice(sourceIndex, 1);
+        const destinationItems = [...destinationGroup.items];
+        if (destIndex === null) {
+          destIndex = destinationItems.length;
+        }
+        destinationItems.splice(destIndex, 0, removed);
+        return groups.map((group) =>
+          group.title === sourceGroup.title
+            ? { ...group, items: sourceItems }
+            : group.title === destinationGroup.title
+              ? { ...group, items: destinationItems }
+              : group,
+        );
+      });
     }
   }, [setUserDashboard]);
 }

--- a/packages/diracx-web-components/src/components/shared/ApplicationSelector.tsx
+++ b/packages/diracx-web-components/src/components/shared/ApplicationSelector.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { use, useMemo, useEffect } from "react";
 import { Typography } from "@mui/material";
-import { ApplicationsContext } from "../../contexts";
+import {
+  AppListContext,
+  CurrentAppContext,
+  DashboardContext,
+} from "../../contexts";
 
 /**
  * ApplicationSelector component renders the currently selected application
@@ -9,8 +13,9 @@ import { ApplicationsContext } from "../../contexts";
  * If no application is selected, it defaults to the first available application.
  */
 export function ApplicationSelector() {
-  const [userDashboard, , applicationList, currentAppId, setCurrentAppId] =
-    use(ApplicationsContext);
+  const { appList: applicationList } = use(AppListContext);
+  const { userDashboard } = use(DashboardContext);
+  const { currentAppId, setCurrentAppId } = use(CurrentAppContext);
 
   const group = userDashboard.find((group) =>
     group.items.some((item) => item.id === currentAppId),

--- a/packages/diracx-web-components/src/contexts/ApplicationsProvider.tsx
+++ b/packages/diracx-web-components/src/contexts/ApplicationsProvider.tsx
@@ -1,21 +1,70 @@
 "use client";
 
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext, useEffect, useMemo, useState } from "react";
 import { applicationList } from "../components/applicationList";
 import { defaultDashboard } from "../components/defaultDashboard";
 import { DashboardGroup } from "../types/DashboardGroup";
 import ApplicationMetadata from "../types/ApplicationMetadata";
 
-// Create a context for the UserDashboard state
-export const ApplicationsContext = createContext<
-  [
-    DashboardGroup[],
-    React.Dispatch<React.SetStateAction<DashboardGroup[]>>,
-    ApplicationMetadata[],
-    string, // Id of the current application
-    React.Dispatch<React.SetStateAction<string>>,
-  ]
->([[], () => {}, [], "", () => {}]);
+// Stable context for app list (rarely changes)
+export interface AppListContextType {
+  appList: ApplicationMetadata[];
+}
+
+export const AppListContext = createContext<AppListContextType>({
+  appList: [],
+});
+
+// Dashboard context (changes on drag-drop, add/remove of applications)
+export interface DashboardContextType {
+  userDashboard: DashboardGroup[];
+  setUserDashboard: React.Dispatch<React.SetStateAction<DashboardGroup[]>>;
+}
+
+export const DashboardContext = createContext<DashboardContextType>({
+  userDashboard: [],
+  setUserDashboard: () => {},
+});
+
+// Narrow context carrying only the current application id, so that
+// dashboard edits (drag-drop, rename, add/remove) do not re-render
+// consumers that only care about which app is selected.
+export interface CurrentAppContextType {
+  currentAppId: string;
+  setCurrentAppId: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const CurrentAppContext = createContext<CurrentAppContextType>({
+  currentAppId: "",
+  setCurrentAppId: () => {},
+});
+
+/**
+ * Structurally validates a value loaded from sessionStorage before
+ * trusting it as a DashboardGroup[].
+ */
+function isDashboardGroupArray(value: unknown): value is DashboardGroup[] {
+  return (
+    Array.isArray(value) &&
+    value.every((group) => {
+      if (typeof group !== "object" || group === null) return false;
+      const g = group as Partial<DashboardGroup>;
+      return (
+        typeof g.title === "string" &&
+        typeof g.extended === "boolean" &&
+        Array.isArray(g.items) &&
+        g.items.every(
+          (item) =>
+            typeof item === "object" &&
+            item !== null &&
+            typeof item.id === "string" &&
+            typeof item.title === "string" &&
+            typeof item.type === "string",
+        )
+      );
+    })
+  );
+}
 
 interface ApplicationsProviderProps {
   children: React.ReactNode;
@@ -36,14 +85,26 @@ export const ApplicationsProvider = ({
   appList = applicationList,
   defaultUserDashboard = defaultDashboard,
 }: ApplicationsProviderProps) => {
-  const loadedDashboard = sessionStorage.getItem("savedDashboard");
-  const parsedDashboard: DashboardGroup[] | null = loadedDashboard
-    ? JSON.parse(loadedDashboard)
-    : null;
-
-  const [userDashboard, setUserDashboard] = useState(
-    parsedDashboard ? parsedDashboard : defaultUserDashboard,
-  );
+  const [userDashboard, setUserDashboard] = useState<DashboardGroup[]>(() => {
+    if (typeof sessionStorage === "undefined") return defaultUserDashboard;
+    const loaded = sessionStorage.getItem("savedDashboard");
+    if (!loaded) return defaultUserDashboard;
+    try {
+      const parsed: unknown = JSON.parse(loaded);
+      if (!isDashboardGroupArray(parsed)) {
+        console.warn(
+          'Dashboard state from sessionStorage ("savedDashboard") has an unexpected shape. Using defaults.',
+        );
+        return defaultUserDashboard;
+      }
+      return parsed;
+    } catch {
+      console.warn(
+        'Failed to parse dashboard state from sessionStorage ("savedDashboard"). Using defaults.',
+      );
+      return defaultUserDashboard;
+    }
+  });
 
   const [currentAppId, setCurrentAppId] = useState<string>(
     userDashboard[0]?.items[0]?.id || "",
@@ -54,19 +115,31 @@ export const ApplicationsProvider = ({
     sessionStorage.setItem("savedDashboard", JSON.stringify(userDashboard));
   }, [userDashboard]);
 
+  const appListValue = useMemo(
+    (): AppListContextType => ({ appList }),
+    [appList],
+  );
+
+  const dashboardValue = useMemo(
+    (): DashboardContextType => ({
+      userDashboard,
+      setUserDashboard,
+    }),
+    [userDashboard],
+  );
+
+  const currentAppValue = useMemo(
+    (): CurrentAppContextType => ({ currentAppId, setCurrentAppId }),
+    [currentAppId],
+  );
+
   return (
-    <ApplicationsContext
-      value={[
-        userDashboard,
-        (group) => {
-          setUserDashboard(group);
-        },
-        appList,
-        currentAppId,
-        setCurrentAppId,
-      ]}
-    >
-      {children}
-    </ApplicationsContext>
+    <AppListContext value={appListValue}>
+      <DashboardContext value={dashboardValue}>
+        <CurrentAppContext value={currentAppValue}>
+          {children}
+        </CurrentAppContext>
+      </DashboardContext>
+    </AppListContext>
   );
 };

--- a/packages/diracx-web-components/src/contexts/NavigationProvider.tsx
+++ b/packages/diracx-web-components/src/contexts/NavigationProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 
 export interface NavigationContextType {
   getPath: () => string;
@@ -27,9 +27,10 @@ export const NavigationProvider = ({
   setPath,
   getSearchParams,
 }: NavigationProviderProps) => {
-  return (
-    <NavigationContext value={{ getPath, setPath, getSearchParams }}>
-      {children}
-    </NavigationContext>
+  const contextValue = useMemo(
+    () => ({ getPath, setPath, getSearchParams }),
+    [getPath, setPath, getSearchParams],
   );
+
+  return <NavigationContext value={contextValue}>{children}</NavigationContext>;
 };

--- a/packages/diracx-web-components/src/contexts/OIDCConfigurationProvider.tsx
+++ b/packages/diracx-web-components/src/contexts/OIDCConfigurationProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, createContext } from "react";
+import React, { useState, createContext, useMemo } from "react";
 import { OidcConfiguration } from "@axa-fr/react-oidc";
 import { OIDCProvider } from "../components/OIDC/OIDCProvider";
 
@@ -34,13 +34,13 @@ export const OIDCConfigurationProvider = ({
     null,
   );
 
+  const contextValue = useMemo(
+    () => ({ configuration, setConfiguration }),
+    [configuration],
+  );
+
   return (
-    <OIDCConfigurationContext
-      value={{
-        configuration,
-        setConfiguration,
-      }}
-    >
+    <OIDCConfigurationContext value={contextValue}>
       <OIDCProvider>{children}</OIDCProvider>
     </OIDCConfigurationContext>
   );

--- a/packages/diracx-web-components/src/contexts/index.ts
+++ b/packages/diracx-web-components/src/contexts/index.ts
@@ -1,13 +1,22 @@
 export {
-  ApplicationsContext,
   ApplicationsProvider,
+  AppListContext,
+  CurrentAppContext,
+  DashboardContext,
+  type AppListContextType,
+  type CurrentAppContextType,
+  type DashboardContextType,
 } from "./ApplicationsProvider";
 export {
   OIDCConfigurationContext,
   OIDCConfigurationProvider,
 } from "./OIDCConfigurationProvider";
 export { DiracXWebProviders } from "./DiracXWebProviders";
-export * from "./NavigationProvider";
+export {
+  type NavigationContextType,
+  NavigationContext,
+  NavigationProvider,
+} from "./NavigationProvider";
 export {
   ThemeContext,
   ThemeProvider,

--- a/packages/diracx-web-components/src/hooks/application.tsx
+++ b/packages/diracx-web-components/src/hooks/application.tsx
@@ -1,56 +1,54 @@
 "use client";
 
 import { use, useMemo } from "react";
-import { ApplicationsContext } from "../contexts/ApplicationsProvider";
+import {
+  AppListContext,
+  CurrentAppContext,
+  DashboardContext,
+} from "../contexts/ApplicationsProvider";
 
 /**
- * Custom hook to access the application id from the context
+ * Custom hook to access the app list from the context
+ * @returns the app list context value
+ */
+export function useAppList() {
+  return use(AppListContext);
+}
+
+/**
+ * Custom hook to access the dashboard state from the context
+ * @returns the dashboard context value
+ */
+export function useDashboard() {
+  return use(DashboardContext);
+}
+
+/**
+ * Custom hook to access the application id from the context.
+ * Subscribes to the narrow CurrentAppContext so dashboard edits
+ * (drag-drop, rename, add/remove) do not re-render consumers.
  * @returns the application id
  */
 export function useApplicationId() {
-  const [, , , appId] = use(ApplicationsContext);
-  return appId;
+  const { currentAppId } = use(CurrentAppContext);
+  return currentAppId;
 }
 
 /**
- * Custom hook to access the application title based on the application id
- * @returns the application title
+ * Custom hook to find the current application (by ID) in the dashboard.
+ * @returns the current dashboard item, or null if not found
  */
-export function useApplicationTitle() {
-  const [userDashboard, , , appId] = use(ApplicationsContext);
+export function useCurrentApplication() {
+  const { userDashboard } = use(DashboardContext);
+  const { currentAppId: appId } = use(CurrentAppContext);
 
   return useMemo(() => {
     if (!userDashboard || !appId) return null;
 
-    const app = userDashboard.reduce(
-      (acc, group) => {
-        if (acc) return acc;
-        return group.items.find((app) => app.id === appId);
-      },
-      undefined as { title: string } | undefined,
-    );
-    return app?.title;
-  }, [userDashboard, appId]);
-}
-
-/**
- * Custom hook to access the application title based on the application id
- * @returns the application type
- */
-export function useApplicationType() {
-  const [userDashboard] = use(ApplicationsContext);
-  const appId = useApplicationId();
-
-  return useMemo(() => {
-    if (!userDashboard || !appId) return null;
-
-    const app = userDashboard.reduce(
-      (acc, group) => {
-        if (acc) return acc;
-        return group.items.find((app) => app.id === appId);
-      },
-      undefined as { type: string } | undefined,
-    );
-    return app?.type;
+    for (const group of userDashboard) {
+      const item = group.items.find((app) => app.id === appId);
+      if (item) return item;
+    }
+    return null;
   }, [userDashboard, appId]);
 }

--- a/packages/diracx-web-components/src/hooks/index.ts
+++ b/packages/diracx-web-components/src/hooks/index.ts
@@ -1,6 +1,11 @@
-export * from "./metadata";
-export * from "./oidcConfiguration";
-export * from "./searchParamsUtils";
-export * from "./theme";
-export * from "./utils";
-export * from "./application";
+export { type Metadata, useMetadata } from "./metadata";
+export { useOIDCContext } from "./oidcConfiguration";
+export { useSearchParamsUtils } from "./searchParamsUtils";
+export { useTheme } from "./theme";
+export { fetcher, useDiracxUrl } from "./utils";
+export {
+  useAppList,
+  useDashboard,
+  useApplicationId,
+  useCurrentApplication,
+} from "./application";

--- a/packages/diracx-web-components/src/types/ApplicationMetadata.ts
+++ b/packages/diracx-web-components/src/types/ApplicationMetadata.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { SvgIconComponent } from "@mui/icons-material";
+import type { SvgIconComponent } from "@mui/icons-material";
 import { ElementType } from "react";
 
 export default interface ApplicationMetadata {

--- a/packages/diracx-web-components/stories/Dashboard.stories.tsx
+++ b/packages/diracx-web-components/stories/Dashboard.stories.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { Box } from "@mui/material";
-import { ApplicationsContext } from "../src/contexts/ApplicationsProvider";
+import {
+  AppListContext,
+  CurrentAppContext,
+  DashboardContext,
+} from "../src/contexts/ApplicationsProvider";
 import { NavigationProvider } from "../src/contexts/NavigationProvider";
 import { applicationList } from "../src/components/applicationList";
 import { DashboardGroup } from "../src/types/DashboardGroup";
@@ -47,21 +51,17 @@ const meta = {
             return url;
           }}
         >
-          <ApplicationsContext.Provider
-            value={[
-              userDashboard,
-              setUserDashboard,
-              applicationList,
-              currentAppId,
-              setCurrentAppId,
-            ]}
-          >
-            <ThemeProvider>
-              <Box sx={{ height: "50vh" }}>
-                <Story />
-              </Box>
-            </ThemeProvider>
-          </ApplicationsContext.Provider>
+          <AppListContext value={{ appList: applicationList }}>
+            <DashboardContext value={{ userDashboard, setUserDashboard }}>
+              <CurrentAppContext value={{ currentAppId, setCurrentAppId }}>
+                <ThemeProvider>
+                  <Box sx={{ height: "50vh" }}>
+                    <Story />
+                  </Box>
+                </ThemeProvider>
+              </CurrentAppContext>
+            </DashboardContext>
+          </AppListContext>
         </NavigationProvider>
       );
     },


### PR DESCRIPTION
Part of #494 (stack 3/5). **Stacked on #496** — until it merges, review the last commit only (`refactor(dashboard)`).

Dashboard/drawer refactor and context granularity:

- splits the monolithic applications context into three purpose-built contexts — **AppList / Dashboard / CurrentApp** — so components only re-render for the state they actually read (previously, dragging or renaming a drawer item re-rendered every running application);
- extracts drag-and-drop into a `useDashboardDragDrop` hook (stable-ref pattern, drop targets no longer re-register on every render) and the context menu into `DrawerContextMenu`;
- makes all dashboard state updates **immutable** — the previous code pushed into arrays held by React state (one dialog only opened by accident of an unrelated re-render) and keyed drag-reorderable lists by index;
- rebuilds the hooks on the granular contexts (`useAppList`, `useDashboard`, `useApplicationId`, `useCurrentApplication`).

**Note for extension authors**: `useApplicationTitle`/`useApplicationType` are removed; state restored from storage is now structurally validated before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
